### PR TITLE
Add Hero input component and capture system

### DIFF
--- a/Assets/Scripts/Hero/HeroInputComponent.cs
+++ b/Assets/Scripts/Hero/HeroInputComponent.cs
@@ -1,0 +1,30 @@
+using Unity.Entities;
+using Unity.Mathematics;
+
+/// <summary>
+/// Stores input values for the hero. Other systems can read these values
+/// to drive movement, abilities and combat.
+/// </summary>
+public struct HeroInputComponent : IComponentData
+{
+    /// <summary>Direction on the XZ plane from WASD keys.</summary>
+    public float2 moveInput;
+
+    /// <summary>True while left shift is held.</summary>
+    public bool isSprinting;
+
+    /// <summary>True while space bar is held.</summary>
+    public bool isJumping;
+
+    /// <summary>True while left mouse button is held.</summary>
+    public bool isAttacking;
+
+    /// <summary>True while Q key is held.</summary>
+    public bool useSkill1;
+
+    /// <summary>True while E key is held.</summary>
+    public bool useSkill2;
+
+    /// <summary>True while R key is held.</summary>
+    public bool useUltimate;
+}

--- a/Assets/Scripts/Hero/HeroInputSystem.cs
+++ b/Assets/Scripts/Hero/HeroInputSystem.cs
@@ -1,0 +1,49 @@
+using Unity.Entities;
+using Unity.Mathematics;
+using UnityEngine.InputSystem;
+
+/// <summary>
+/// System that captures keyboard and mouse input using the Unity Input System
+/// and writes the result to <see cref="HeroInputComponent"/>. Only runs for
+/// the entity tagged with <see cref="IsLocalPlayer"/>.
+/// </summary>
+[UpdateInGroup(typeof(SimulationSystemGroup))]
+public partial class HeroInputSystem : SystemBase
+{
+    protected override void OnUpdate()
+    {
+        var keyboard = Keyboard.current;
+        var mouse = Mouse.current;
+
+        foreach (var entity in SystemAPI.Query<Entity>().WithAll<HeroInputComponent, IsLocalPlayer>())
+        {
+            var input = new HeroInputComponent();
+
+            // Gather directional input (XZ plane).
+            if (keyboard != null)
+            {
+                float x = 0f;
+                float z = 0f;
+                if (keyboard.aKey.isPressed) x -= 1f;
+                if (keyboard.dKey.isPressed) x += 1f;
+                if (keyboard.sKey.isPressed) z -= 1f;
+                if (keyboard.wKey.isPressed) z += 1f;
+                input.moveInput = new float2(x, z);
+
+                input.isSprinting = keyboard.leftShiftKey.isPressed;
+                input.isJumping = keyboard.spaceKey.isPressed;
+                input.useSkill1 = keyboard.qKey.isPressed;
+                input.useSkill2 = keyboard.eKey.isPressed;
+                input.useUltimate = keyboard.rKey.isPressed;
+            }
+
+            if (mouse != null)
+            {
+                input.isAttacking = mouse.leftButton.isPressed;
+            }
+
+            // Write the captured values back to the entity component.
+            SystemAPI.SetComponent(entity, input);
+        }
+    }
+}

--- a/Assets/Scripts/Hero/IsLocalPlayer.cs
+++ b/Assets/Scripts/Hero/IsLocalPlayer.cs
@@ -1,0 +1,10 @@
+using Unity.Entities;
+
+/// <summary>
+/// Tag component used to identify the local player's entity.
+/// Systems that should operate only on the local player can
+/// query for this component.
+/// </summary>
+public struct IsLocalPlayer : IComponentData
+{
+}


### PR DESCRIPTION
## Summary
- add ECS component `HeroInputComponent` for storing keyboard/mouse input
- add `IsLocalPlayer` tag component to mark the local player
- implement `HeroInputSystem` that reads the Unity Input System and updates the component

## Testing
- `dotnet build prototipo_curado.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bfc454e348332a24cf02a04e8def2