### PR TITLE
Add hero movement ECS system

### DIFF
--- a/Assets/Scripts/Game.ECS.asmdef
+++ b/Assets/Scripts/Game.ECS.asmdef
@@ -6,7 +6,8 @@
 		"Unity.Mathematics",
 		"Unity.Transforms",
 		"Unity.RenderPipelines.Universal",
-		"Unity.Rendering.Hybrid",
-		"Unity.Burst"
-	]
+                "Unity.Rendering.Hybrid",
+                "Unity.Burst",
+                "Unity.Physics"
+        ]
 }

--- a/Assets/Scripts/Hero/HeroGroundState.cs
+++ b/Assets/Scripts/Hero/HeroGroundState.cs
@@ -1,0 +1,10 @@
+using Unity.Entities;
+
+/// <summary>
+/// Represents whether the hero is currently grounded.
+/// Other systems should update this flag based on collisions.
+/// </summary>
+public struct HeroGroundState : IComponentData
+{
+    public bool isGrounded;
+}

--- a/Assets/Scripts/Hero/HeroLifeComponent.cs
+++ b/Assets/Scripts/Hero/HeroLifeComponent.cs
@@ -1,0 +1,10 @@
+using Unity.Entities;
+
+/// <summary>
+/// Tracks the alive/dead state of the hero.
+/// </summary>
+public struct HeroLifeComponent : IComponentData
+{
+    /// <summary>True if the hero can move and interact.</summary>
+    public bool isAlive;
+}

--- a/Assets/Scripts/Hero/HeroMovementSystem.cs
+++ b/Assets/Scripts/Hero/HeroMovementSystem.cs
@@ -1,0 +1,61 @@
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using Unity.Physics;
+
+/// <summary>
+/// Handles physical movement and orientation of the local hero based on
+/// <see cref="HeroInputComponent"/> data.
+/// </summary>
+[UpdateInGroup(typeof(SimulationSystemGroup))]
+public partial class HeroMovementSystem : SystemBase
+{
+    protected override void OnUpdate()
+    {
+        float deltaTime = SystemAPI.Time.DeltaTime;
+
+        foreach (var (input, stats, life, velocity, mass, transform, entity) in
+                 SystemAPI.Query<RefRO<HeroInputComponent>,
+                                 RefRO<HeroStatsComponent>,
+                                 RefRO<HeroLifeComponent>,
+                                 RefRW<PhysicsVelocity>,
+                                 RefRO<PhysicsMass>,
+                                 RefRW<LocalTransform>>()
+                        .WithAll<IsLocalPlayer>()
+                        .WithEntityAccess())
+        {
+            if (!life.ValueRO.isAlive)
+                continue;
+
+            float3 move = new float3(input.ValueRO.moveInput.x, 0f, input.ValueRO.moveInput.y);
+            float speed = stats.ValueRO.baseSpeed;
+            if (input.ValueRO.isSprinting)
+                speed *= stats.ValueRO.sprintMultiplier;
+
+            float3 desired = math.normalizesafe(move) * speed;
+
+            var vel = velocity.ValueRW;
+            vel.Linear.x = desired.x;
+            vel.Linear.z = desired.z;
+
+            if (input.ValueRO.isJumping)
+            {
+                if (SystemAPI.HasComponent<HeroGroundState>(entity) &&
+                    SystemAPI.GetComponent<HeroGroundState>(entity).isGrounded)
+                {
+                    vel.Linear.y = stats.ValueRO.jumpForce;
+                    var ground = SystemAPI.GetComponentRW<HeroGroundState>(entity);
+                    ground.ValueRW.isGrounded = false;
+                }
+            }
+
+            velocity.ValueRW = vel;
+
+            if (!math.all(move == float3.zero))
+            {
+                quaternion targetRot = quaternion.LookRotationSafe(move, math.up());
+                transform.ValueRW.Rotation = math.slerp(transform.ValueRW.Rotation, targetRot, deltaTime * 10f);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Hero/HeroStatsComponent.cs
+++ b/Assets/Scripts/Hero/HeroStatsComponent.cs
@@ -1,0 +1,16 @@
+using Unity.Entities;
+
+/// <summary>
+/// Stores basic movement related stats for the hero.
+/// </summary>
+public struct HeroStatsComponent : IComponentData
+{
+    /// <summary>Base walking speed.</summary>
+    public float baseSpeed;
+
+    /// <summary>Multiplier applied when sprinting.</summary>
+    public float sprintMultiplier;
+
+    /// <summary>Force applied when jumping.</summary>
+    public float jumpForce;
+}


### PR DESCRIPTION
## Summary
- add `HeroStatsComponent`, `HeroLifeComponent` and `HeroGroundState` data
- implement `HeroMovementSystem` to move and rotate the local hero using input and DOTS physics
- include Unity.Physics in `Game.ECS` assembly definition

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c04157a9c83329bef960c42dfacfe