### PR TITLE
Implement SquadOrderSystem

### DIFF
--- a/Assets/Scripts/Squads/SquadFSMStateComponent.cs
+++ b/Assets/Scripts/Squads/SquadFSMStateComponent.cs
@@ -1,0 +1,24 @@
+using Unity.Entities;
+
+/// <summary>
+/// Current finite state of a squad. Other systems use this value
+/// to drive behaviour transitions.
+/// </summary>
+public struct SquadFSMStateComponent : IComponentData
+{
+    /// <summary>Current state of the squad FSM.</summary>
+    public SquadFSMState currentState;
+}
+
+/// <summary>
+/// Enumeration of possible squad states.
+/// </summary>
+public enum SquadFSMState
+{
+    Idle,
+    FollowingHero,
+    HoldingPosition,
+    Attacking,
+    Retreating,
+    KO
+}

--- a/Assets/Scripts/Squads/SquadOrderSystem.cs
+++ b/Assets/Scripts/Squads/SquadOrderSystem.cs
@@ -1,0 +1,52 @@
+using Unity.Entities;
+
+/// <summary>
+/// System that interprets the <see cref="SquadInputComponent"/> and updates
+/// <see cref="SquadStateComponent"/> accordingly. It only runs when a new
+/// order has been issued.
+/// </summary>
+[UpdateInGroup(typeof(SimulationSystemGroup))]
+public partial class SquadOrderSystem : SystemBase
+{
+    protected override void OnUpdate()
+    {
+        foreach (var (input, state, entity) in SystemAPI
+                     .Query<RefRW<SquadInputComponent>, RefRW<SquadStateComponent>>()
+                     .WithEntityAccess())
+        {
+            if (!input.ValueRO.hasNewOrder)
+                continue;
+
+            // Copy the requested order to the state component
+            state.ValueRW.currentOrder = input.ValueRO.orderType;
+            state.ValueRW.isExecutingOrder = true;
+
+            // Request formation change if needed
+            if (input.ValueRO.desiredFormation != state.ValueRO.currentFormation)
+            {
+                state.ValueRW.currentFormation = input.ValueRO.desiredFormation;
+            }
+
+            // Attempt to update FSM state if the entity has such component
+            if (SystemAPI.HasComponent<SquadFSMStateComponent>(entity))
+            {
+                var fsm = SystemAPI.GetComponentRW<SquadFSMStateComponent>(entity);
+                if (fsm.ValueRO.currentState != OrderToState(input.ValueRO.orderType))
+                    fsm.ValueRW.currentState = OrderToState(input.ValueRO.orderType);
+            }
+
+            input.ValueRW.hasNewOrder = false;
+        }
+    }
+
+    static SquadFSMState OrderToState(SquadOrderType order)
+    {
+        return order switch
+        {
+            SquadOrderType.FollowHero => SquadFSMState.FollowingHero,
+            SquadOrderType.HoldPosition => SquadFSMState.HoldingPosition,
+            SquadOrderType.Attack => SquadFSMState.Attacking,
+            _ => SquadFSMState.Idle,
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add an enum and component to represent squad FSM state
- implement `SquadOrderSystem` to copy new orders from `SquadInputComponent` to `SquadStateComponent`
- update FSM state when orders change and request formation updates

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c0e91172083329b000b249ad4e5e9