### PR TITLE
Implement FormationSystem with formation data blobs

### DIFF
--- a/Assets/Scripts/Squads/FormationLibraryBlob.cs
+++ b/Assets/Scripts/Squads/FormationLibraryBlob.cs
@@ -1,0 +1,23 @@
+using Unity.Entities;
+using Unity.Mathematics;
+
+/// <summary>
+/// Blob asset containing all formation patterns available to a squad.
+/// </summary>
+public struct FormationLibraryBlob
+{
+    /// <summary>Array of formations contained in this library.</summary>
+    public BlobArray<FormationDataBlob> formations;
+}
+
+/// <summary>
+/// Blob representation of a single formation.
+/// </summary>
+public struct FormationDataBlob
+{
+    /// <summary>Formation type.</summary>
+    public FormationType formationType;
+
+    /// <summary>Offsets relative to the leader.</summary>
+    public BlobArray<float3> localOffsets;
+}

--- a/Assets/Scripts/Squads/FormationScriptableObject.cs
+++ b/Assets/Scripts/Squads/FormationScriptableObject.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+/// <summary>
+/// Defines a formation pattern relative to the squad leader.
+/// </summary>
+[CreateAssetMenu(menuName = "Formations/Formation Pattern")]
+public class FormationScriptableObject : ScriptableObject
+{
+    /// <summary>Formation this pattern represents.</summary>
+    public FormationType formationType;
+
+    /// <summary>Offsets relative to the leader for each unit.</summary>
+    public Vector3[] localOffsets;
+}

--- a/Assets/Scripts/Squads/FormationSystem.cs
+++ b/Assets/Scripts/Squads/FormationSystem.cs
@@ -1,0 +1,88 @@
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+/// <summary>
+/// Assigns target positions to squad units based on the selected formation.
+/// </summary>
+[UpdateInGroup(typeof(SimulationSystemGroup))]
+public partial class FormationSystem : SystemBase
+{
+    protected override void OnUpdate()
+    {
+        float deltaTime = SystemAPI.Time.DeltaTime;
+
+        foreach (var (input, state, formationData, units) in SystemAPI
+                     .Query<RefRO<SquadInputComponent>,
+                            RefRW<SquadStateComponent>,
+                            RefRO<SquadFormationDataComponent>,
+                            DynamicBuffer<SquadUnitElement>>())
+        {
+            var s = state.ValueRW;
+            s.formationChangeCooldown = math.max(0f, s.formationChangeCooldown - deltaTime);
+
+            if (input.ValueRO.desiredFormation == s.currentFormation ||
+                s.formationChangeCooldown > 0f)
+            {
+                state.ValueRW = s;
+                continue;
+            }
+
+            if (!formationData.ValueRO.formationLibrary.IsCreated || units.Length == 0)
+            {
+                state.ValueRW = s;
+                continue;
+            }
+
+            var formations = formationData.ValueRO.formationLibrary.Value.formations;
+            BlobArray<float3> offsets = default;
+            bool found = false;
+            for (int i = 0; i < formations.Length; i++)
+            {
+                if (formations[i].formationType == input.ValueRO.desiredFormation)
+                {
+                    offsets = formations[i].localOffsets;
+                    found = true;
+                    break;
+                }
+            }
+            if (!found)
+            {
+                state.ValueRW = s;
+                continue;
+            }
+
+            Entity leader = units[0].Value;
+            if (!SystemAPI.Exists(leader))
+            {
+                state.ValueRW = s;
+                continue;
+            }
+
+            float3 leaderPos = SystemAPI.GetComponent<LocalTransform>(leader).Position;
+
+            int count = math.min(units.Length, offsets.Length);
+            for (int i = 0; i < count; i++)
+            {
+                Entity unit = units[i].Value;
+                if (!SystemAPI.Exists(unit))
+                    continue;
+
+                float3 target = leaderPos + offsets[i];
+                if (SystemAPI.HasComponent<UnitTargetPositionComponent>(unit))
+                {
+                    var targetPos = SystemAPI.GetComponentRW<UnitTargetPositionComponent>(unit);
+                    targetPos.ValueRW.position = target;
+                }
+                else
+                {
+                    SystemAPI.AddComponent(unit, new UnitTargetPositionComponent { position = target });
+                }
+            }
+
+            s.currentFormation = input.ValueRO.desiredFormation;
+            s.formationChangeCooldown = 1f;
+            state.ValueRW = s;
+        }
+    }
+}

--- a/Assets/Scripts/Squads/SquadFormationDataAuthoring.cs
+++ b/Assets/Scripts/Squads/SquadFormationDataAuthoring.cs
@@ -1,0 +1,35 @@
+using Unity.Collections;
+using Unity.Entities;
+using UnityEngine;
+
+/// <summary>
+/// MonoBehaviour used to bake formation data from scriptable objects into a blob asset.
+/// </summary>
+public class SquadFormationDataAuthoring : MonoBehaviour
+{
+    public FormationScriptableObject[] formations;
+
+    class Baker : Unity.Entities.Baker<SquadFormationDataAuthoring>
+    {
+        public override void Bake(SquadFormationDataAuthoring authoring)
+        {
+            var builder = new BlobBuilder(Allocator.Temp);
+            ref var root = ref builder.ConstructRoot<FormationLibraryBlob>();
+            var formationArray = builder.Allocate(ref root.formations, authoring.formations.Length);
+            for (int i = 0; i < authoring.formations.Length; i++)
+            {
+                var form = authoring.formations[i];
+                formationArray[i].formationType = form.formationType;
+                var offsets = builder.Allocate(ref formationArray[i].localOffsets, form.localOffsets.Length);
+                for (int j = 0; j < form.localOffsets.Length; j++)
+                    offsets[j] = form.localOffsets[j];
+            }
+
+            var blob = builder.CreateBlobAssetReference<FormationLibraryBlob>(Allocator.Persistent);
+            builder.Dispose();
+
+            var entity = GetEntity(TransformUsageFlags.None);
+            AddComponent(entity, new SquadFormationDataComponent { formationLibrary = blob });
+        }
+    }
+}

--- a/Assets/Scripts/Squads/SquadFormationDataComponent.cs
+++ b/Assets/Scripts/Squads/SquadFormationDataComponent.cs
@@ -1,0 +1,10 @@
+using Unity.Entities;
+
+/// <summary>
+/// References the formation patterns available to a squad.
+/// </summary>
+public struct SquadFormationDataComponent : IComponentData
+{
+    /// <summary>Blob asset with all available formations.</summary>
+    public BlobAssetReference<FormationLibraryBlob> formationLibrary;
+}

--- a/Assets/Scripts/Squads/SquadUnitElement.cs
+++ b/Assets/Scripts/Squads/SquadUnitElement.cs
@@ -1,0 +1,11 @@
+using Unity.Entities;
+
+/// <summary>
+/// Buffer element used to store the entities that belong to a squad.
+/// The first element is considered the leader.
+/// </summary>
+public struct SquadUnitElement : IBufferElementData
+{
+    /// <summary>Entity representing the squad member.</summary>
+    public Entity Value;
+}

--- a/Assets/Scripts/Squads/UnitTargetPositionComponent.cs
+++ b/Assets/Scripts/Squads/UnitTargetPositionComponent.cs
@@ -1,0 +1,11 @@
+using Unity.Entities;
+using Unity.Mathematics;
+
+/// <summary>
+/// Desired world position for a squad unit. Other systems should
+/// move the unit towards this position.
+/// </summary>
+public struct UnitTargetPositionComponent : IComponentData
+{
+    public float3 position;
+}


### PR DESCRIPTION
## Summary
- add `FormationScriptableObject` to define formation patterns
- define `FormationLibraryBlob` and supporting ECS components
- author a baker to convert scriptable objects into blobs
- add `UnitTargetPositionComponent` and `SquadUnitElement` buffer
- implement `FormationSystem` for assigning target positions to squad units

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c1b2b970483329d5ce4ce8b8f73c5