### PR TITLE
Implement SquadAISystem

### DIFF
--- a/Assets/Scripts/Squads/DetectedEnemy.cs
+++ b/Assets/Scripts/Squads/DetectedEnemy.cs
@@ -1,0 +1,10 @@
+using Unity.Entities;
+
+/// <summary>
+/// Buffer element containing detected enemy entities within range of a squad.
+/// </summary>
+public struct DetectedEnemy : IBufferElementData
+{
+    /// <summary>Enemy entity reference.</summary>
+    public Entity Value;
+}

--- a/Assets/Scripts/Squads/SquadAIComponent.cs
+++ b/Assets/Scripts/Squads/SquadAIComponent.cs
@@ -1,0 +1,27 @@
+using Unity.Entities;
+
+/// <summary>
+/// Possible tactical AI states for a squad.
+/// </summary>
+public enum SquadAIState
+{
+    Idle,
+    Attacking,
+    Regrouping,
+    Defending
+}
+
+/// <summary>
+/// Component that tracks the current AI state of a squad.
+/// </summary>
+public struct SquadAIComponent : IComponentData
+{
+    /// <summary>Current AI state.</summary>
+    public SquadAIState state;
+
+    /// <summary>Current target entity if any.</summary>
+    public Entity targetEntity;
+
+    /// <summary>True if the squad is actively engaged in combat.</summary>
+    public bool isInCombat;
+}

--- a/Assets/Scripts/Squads/SquadAISystem.cs
+++ b/Assets/Scripts/Squads/SquadAISystem.cs
@@ -1,0 +1,76 @@
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+/// <summary>
+/// Decides the tactical AI state for each squad based on the current order,
+/// detected enemies and squad cohesion. Movement or attacks are handled by
+/// other systems.
+/// </summary>
+[UpdateInGroup(typeof(SimulationSystemGroup))]
+public partial class SquadAISystem : SystemBase
+{
+    protected override void OnUpdate()
+    {
+        const float cohesionRadiusSq = 25f; // Distance squared to consider units scattered
+
+        foreach (var (ai, state, units, entity) in SystemAPI
+                     .Query<RefRW<SquadAIComponent>,
+                            RefRO<SquadStateComponent>,
+                            DynamicBuffer<SquadUnitElement>>()
+                     .WithEntityAccess())
+        {
+            bool enemiesDetected = false;
+            if (SystemAPI.HasBuffer<DetectedEnemy>(entity))
+            {
+                var detected = SystemAPI.GetBuffer<DetectedEnemy>(entity);
+                enemiesDetected = detected.Length > 0;
+            }
+
+            bool dispersed = false;
+            if (units.Length > 0)
+            {
+                Entity leader = units[0].Value;
+                if (SystemAPI.Exists(leader))
+                {
+                    float3 leaderPos = SystemAPI.GetComponent<LocalTransform>(leader).Position;
+                    for (int i = 0; i < units.Length; i++)
+                    {
+                        Entity unit = units[i].Value;
+                        if (!SystemAPI.Exists(unit))
+                            continue;
+
+                        float3 pos = SystemAPI.GetComponent<LocalTransform>(unit).Position;
+                        if (math.distancesq(pos, leaderPos) > cohesionRadiusSq)
+                        {
+                            dispersed = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            SquadAIState desiredState;
+            if (dispersed)
+            {
+                desiredState = SquadAIState.Regrouping;
+            }
+            else if (state.ValueRO.currentOrder == SquadOrderType.FollowHero ||
+                     state.ValueRO.currentOrder == SquadOrderType.Attack)
+            {
+                desiredState = enemiesDetected ? SquadAIState.Attacking : SquadAIState.Idle;
+            }
+            else if (state.ValueRO.currentOrder == SquadOrderType.HoldPosition)
+            {
+                desiredState = enemiesDetected ? SquadAIState.Attacking : SquadAIState.Defending;
+            }
+            else
+            {
+                desiredState = SquadAIState.Idle;
+            }
+
+            ai.ValueRW.state = desiredState;
+            ai.ValueRW.isInCombat = enemiesDetected;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `SquadAIComponent` with `SquadAIState` enum
- add buffer element `DetectedEnemy` for enemy detection
- implement `SquadAISystem` to compute squad AI state based on orders, enemy presence and cohesion

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c21b16d648332a06bf2686cfd7d65