### PR TITLE
Implement damage categories and critical multiplier

### DIFF
--- a/Assets/Scripts/Combat/DamageCalculationSystem.cs
+++ b/Assets/Scripts/Combat/DamageCalculationSystem.cs
@@ -1,0 +1,36 @@
+using Unity.Entities;
+using Unity.Mathematics;
+
+/// <summary>
+/// Applies pending damage events to their targets using the damage profile data.
+/// Critical hits use a multiplier for extra damage.
+/// </summary>
+[UpdateInGroup(typeof(SimulationSystemGroup))]
+public partial class DamageCalculationSystem : SystemBase
+{
+    protected override void OnUpdate()
+    {
+        foreach (var (pending, entity) in SystemAPI
+                     .Query<RefRO<PendingDamageEvent>>()
+                     .WithEntityAccess())
+        {
+            if (!SystemAPI.Exists(pending.ValueRO.target) ||
+                !SystemAPI.Exists(pending.ValueRO.damageProfile))
+            {
+                SystemAPI.RemoveComponent<PendingDamageEvent>(entity);
+                continue;
+            }
+
+            var profile = SystemAPI.GetComponent<DamageProfileData>(pending.ValueRO.damageProfile);
+            float finalDamage = profile.baseDamage * pending.ValueRO.multiplier;
+
+            if (SystemAPI.HasComponent<HealthComponent>(pending.ValueRO.target))
+            {
+                var health = SystemAPI.GetComponentRW<HealthComponent>(pending.ValueRO.target);
+                health.ValueRW.currentHealth = math.max(0f, health.ValueRO.currentHealth - finalDamage);
+            }
+
+            SystemAPI.RemoveComponent<PendingDamageEvent>(entity);
+        }
+    }
+}

--- a/Assets/Scripts/Combat/DamageCategory.cs
+++ b/Assets/Scripts/Combat/DamageCategory.cs
@@ -1,0 +1,9 @@
+/// <summary>
+/// Visual/logic category of damage for popup effects.
+/// </summary>
+public enum DamageCategory
+{
+    Normal,
+    Critical,
+    Ability
+}

--- a/Assets/Scripts/Combat/DamageProfile.cs
+++ b/Assets/Scripts/Combat/DamageProfile.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+/// <summary>
+/// Defines base damage, penetration and type for a weapon.
+/// </summary>
+[CreateAssetMenu(menuName = "Combat/Damage Profile")]
+public class DamageProfile : ScriptableObject
+{
+    /// <summary>Base damage dealt by the attack.</summary>
+    public float baseDamage;
+
+    /// <summary>Type of damage inflicted.</summary>
+    public DamageType damageType;
+
+    /// <summary>Penetration value for the damage.</summary>
+    public float penetration;
+}

--- a/Assets/Scripts/Combat/DamageProfileData.cs
+++ b/Assets/Scripts/Combat/DamageProfileData.cs
@@ -1,0 +1,17 @@
+using Unity.Entities;
+
+/// <summary>
+/// Component holding runtime data for a weapon damage profile.
+/// Typically baked from a <see cref="DamageProfile"/> ScriptableObject.
+/// </summary>
+public struct DamageProfileData : IComponentData
+{
+    /// <summary>Base damage dealt by the attack.</summary>
+    public float baseDamage;
+
+    /// <summary>Type of damage inflicted.</summary>
+    public DamageType damageType;
+
+    /// <summary>Penetration value for the damage.</summary>
+    public float penetration;
+}

--- a/Assets/Scripts/Combat/DamageType.cs
+++ b/Assets/Scripts/Combat/DamageType.cs
@@ -1,0 +1,9 @@
+/// <summary>
+/// Represents the type of damage inflicted by a weapon.
+/// </summary>
+public enum DamageType
+{
+    Blunt,
+    Slashing,
+    Piercing
+}

--- a/Assets/Scripts/Combat/HealthComponent.cs
+++ b/Assets/Scripts/Combat/HealthComponent.cs
@@ -1,0 +1,13 @@
+using Unity.Entities;
+
+/// <summary>
+/// Tracks health for an entity.
+/// </summary>
+public struct HealthComponent : IComponentData
+{
+    /// <summary>Maximum health value.</summary>
+    public float maxHealth;
+
+    /// <summary>Current health remaining.</summary>
+    public float currentHealth;
+}

--- a/Assets/Scripts/Combat/PendingDamageEvent.cs
+++ b/Assets/Scripts/Combat/PendingDamageEvent.cs
@@ -1,0 +1,20 @@
+using Unity.Entities;
+
+/// <summary>
+/// Component used as an event to signal that an entity should receive damage.
+/// The damage is applied by a separate system.
+/// </summary>
+public struct PendingDamageEvent : IComponentData
+{
+    /// <summary>Entity that will receive the damage.</summary>
+    public Entity target;
+
+    /// <summary>Damage profile to apply.</summary>
+    public Entity damageProfile;
+
+    /// <summary>Visual category for popup effects.</summary>
+    public DamageCategory category;
+
+    /// <summary>Damage multiplier (1 for normal, >1 for critical).</summary>
+    public float multiplier;
+}

--- a/Assets/Scripts/Combat/UnitAttackSystem.cs
+++ b/Assets/Scripts/Combat/UnitAttackSystem.cs
@@ -1,0 +1,82 @@
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using UnityEngine;
+
+/// <summary>
+/// Executes melee or ranged attacks for each unit when their target is within
+/// range and the attack cooldown has elapsed.
+/// </summary>
+[UpdateInGroup(typeof(SimulationSystemGroup))]
+public partial class UnitAttackSystem : SystemBase
+{
+    protected override void OnUpdate()
+    {
+        float deltaTime = SystemAPI.Time.DeltaTime;
+
+        foreach (var (combat, weapon, transform, entity) in
+                 SystemAPI.Query<RefRW<UnitCombatComponent>,
+                                 RefRO<UnitWeaponComponent>,
+                                 RefRO<LocalTransform>>()
+                        .WithEntityAccess())
+        {
+            Entity target = combat.ValueRO.target;
+            if (target == Entity.Null || !SystemAPI.Exists(target))
+            {
+                combat.ValueRW.target = Entity.Null;
+                continue;
+            }
+
+            bool targetAlive = true;
+            if (SystemAPI.HasComponent<HealthComponent>(target))
+            {
+                var health = SystemAPI.GetComponent<HealthComponent>(target);
+                targetAlive = health.currentHealth > 0f;
+            }
+            else if (SystemAPI.HasComponent<HeroLifeComponent>(target))
+            {
+                targetAlive = SystemAPI.GetComponent<HeroLifeComponent>(target).isAlive;
+            }
+            if (!targetAlive)
+            {
+                combat.ValueRW.target = Entity.Null;
+                continue;
+            }
+
+            float3 targetPos = float3.zero;
+            if (SystemAPI.HasComponent<LocalTransform>(target))
+            {
+                targetPos = SystemAPI.GetComponent<LocalTransform>(target).Position;
+            }
+            else
+            {
+                continue;
+            }
+
+            float distSq = math.distancesq(transform.ValueRO.Position, targetPos);
+            bool inRange = distSq <= weapon.ValueRO.attackRange * weapon.ValueRO.attackRange;
+
+            var c = combat.ValueRW;
+            c.attackCooldown = math.max(0f, c.attackCooldown - deltaTime);
+
+            if (inRange && c.attackCooldown <= 0f)
+            {
+                if (!SystemAPI.HasComponent<PendingDamageEvent>(entity))
+                {
+                    bool crit = UnityEngine.Random.value <= 0.1f;
+                    SystemAPI.AddComponent(entity, new PendingDamageEvent
+                    {
+                        target = target,
+                        damageProfile = weapon.ValueRO.damageProfile,
+                        category = crit ? DamageCategory.Critical : DamageCategory.Normal,
+                        multiplier = crit ? 1.5f : 1f
+                    });
+                }
+
+                c.attackCooldown = weapon.ValueRO.attackInterval;
+            }
+
+            combat.ValueRW = c;
+        }
+    }
+}

--- a/Assets/Scripts/Combat/UnitWeaponComponent.cs
+++ b/Assets/Scripts/Combat/UnitWeaponComponent.cs
@@ -1,0 +1,16 @@
+using Unity.Entities;
+
+/// <summary>
+/// Stores weapon parameters for a unit.
+/// </summary>
+public struct UnitWeaponComponent : IComponentData
+{
+    /// <summary>Entity holding the damage profile for this weapon.</summary>
+    public Entity damageProfile;
+
+    /// <summary>Maximum distance at which the attack is effective.</summary>
+    public float attackRange;
+
+    /// <summary>Time between consecutive attacks.</summary>
+    public float attackInterval;
+}

--- a/Docs/TDD.md
+++ b/Docs/TDD.md
@@ -727,6 +727,13 @@ csharp
 CopiarEditar
 enum DamageType { Blunt, Slashing, Piercing }
 
+enum DamageCategory { Normal, Critical, Ability }
+
+`DamageCategory` define la representación visual del daño. El valor
+`Critical` aplica un multiplicador de **1.5x** y se muestra con un popup
+mayor y color distinto. `Ability` corresponde a efectos como sangrado y
+usa su propio color.
+
 DamageProfile (ScriptableObject)
 - baseDamage: float
 - damageType: DamageType
@@ -779,6 +786,7 @@ float CalculateEffectiveDamage(float baseDamage, float defense, float penetratio
 DamageCalculationSystem
 - Lee DamageProfile, DefenseComponent y PenetrationComponent
 - Aplica daño resultante a HealthComponent
+ - Aplica multiplicador 1.5f si el `DamageCategory` es `Critical`
 
 HealthComponent (IComponentData)
 - maxHealth: float


### PR DESCRIPTION
## Summary
- add `DamageCategory` enum for normal, critical and ability damage
- extend `PendingDamageEvent` with category and multiplier
- modify `UnitAttackSystem` to randomly trigger critical hits
- introduce `DamageCalculationSystem` and `DamageProfileData`
- document new damage categories and multiplier in TDD

## Testing
- `dotnet build -bl` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c298c0fc08332b58cd95e2c3d3f30