### PR TITLE
Implement FormationAdaptationSystem

### DIFF
--- a/Assets/Scripts/Squads/EnvironmentAwarenessComponent.cs
+++ b/Assets/Scripts/Squads/EnvironmentAwarenessComponent.cs
@@ -1,0 +1,28 @@
+using Unity.Entities;
+
+/// <summary>
+/// Describes the immediate environment around a squad.
+/// Updated by sensors to allow formation adaptation.
+/// </summary>
+public struct EnvironmentAwarenessComponent : IComponentData
+{
+    /// <summary>Radius used for obstacle detection checks.</summary>
+    public float detectionRadius;
+
+    /// <summary>Current type of terrain the squad is navigating.</summary>
+    public TerrainType terrainType;
+
+    /// <summary>True if obstacles were detected near the squad.</summary>
+    public bool obstacleDetected;
+}
+
+/// <summary>
+/// Simple classification of terrain around a squad.
+/// </summary>
+public enum TerrainType
+{
+    Abierto,
+    Estrecho,
+    Escalera,
+    Puerta
+}

--- a/Assets/Scripts/Squads/FormationAdaptationSystem.cs
+++ b/Assets/Scripts/Squads/FormationAdaptationSystem.cs
@@ -1,0 +1,44 @@
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using UnityEngine;
+
+/// <summary>
+/// Automatically adjusts squad formations when traversing narrow spaces
+/// or when obstacles are detected. The player's chosen formation is stored
+/// in <see cref="FormationComponent"/> and restored when space allows.
+/// </summary>
+[UpdateInGroup(typeof(SimulationSystemGroup))]
+public partial class FormationAdaptationSystem : SystemBase
+{
+    protected override void OnUpdate()
+    {
+        foreach (var (env, input, state, formation, units) in SystemAPI
+                     .Query<RefRW<EnvironmentAwarenessComponent>,
+                            RefRW<SquadInputComponent>,
+                            RefRO<SquadStateComponent>,
+                            RefRO<FormationComponent>,
+                            DynamicBuffer<SquadUnitElement>>())
+        {
+            if (state.ValueRO.isInCombat || units.Length == 0)
+                continue;
+
+            Entity leader = units[0].Value;
+            if (!SystemAPI.Exists(leader))
+                continue;
+
+            float3 leaderPos = SystemAPI.GetComponent<LocalTransform>(leader).Position;
+            var envData = env.ValueRW;
+            envData.obstacleDetected = Physics.CheckSphere(leaderPos, envData.detectionRadius);
+            env.ValueRW = envData;
+
+            bool narrow = envData.terrainType != TerrainType.Abierto || envData.obstacleDetected;
+            FormationType desired = narrow ? FormationType.Line : formation.ValueRO.currentFormation;
+
+            if (input.ValueRO.desiredFormation != desired)
+            {
+                input.ValueRW.desiredFormation = desired;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Squads/FormationComponent.cs
+++ b/Assets/Scripts/Squads/FormationComponent.cs
@@ -1,0 +1,21 @@
+using Unity.Entities;
+using Unity.Mathematics;
+
+/// <summary>
+/// Holds the preferred formation for a squad and the dynamic pattern
+/// used by formation systems. The pattern can be modified at runtime
+/// by other systems.
+/// </summary>
+public struct FormationComponent : IComponentData
+{
+    /// <summary>Formation selected by the player.</summary>
+    public FormationType currentFormation;
+}
+
+/// <summary>
+/// Buffer element storing offset positions for a formation pattern.
+/// </summary>
+public struct FormationPatternElement : IBufferElementData
+{
+    public float3 Value;
+}

--- a/Assets/Scripts/Squads/SquadOrderSystem.cs
+++ b/Assets/Scripts/Squads/SquadOrderSystem.cs
@@ -10,8 +10,10 @@ public partial class SquadOrderSystem : SystemBase
 {
     protected override void OnUpdate()
     {
-        foreach (var (input, state, entity) in SystemAPI
-                     .Query<RefRW<SquadInputComponent>, RefRW<SquadStateComponent>>()
+        foreach (var (input, state, formation, entity) in SystemAPI
+                     .Query<RefRW<SquadInputComponent>,
+                            RefRW<SquadStateComponent>,
+                            RefRW<FormationComponent>>()
                      .WithEntityAccess())
         {
             if (!input.ValueRO.hasNewOrder)
@@ -25,6 +27,7 @@ public partial class SquadOrderSystem : SystemBase
             if (input.ValueRO.desiredFormation != state.ValueRO.currentFormation)
             {
                 state.ValueRW.currentFormation = input.ValueRO.desiredFormation;
+                formation.ValueRW.currentFormation = input.ValueRO.desiredFormation;
             }
 
             // Request a state transition if using the FSM system


### PR DESCRIPTION
## Summary
- store player's formation preference in `FormationComponent`
- add `EnvironmentAwarenessComponent` with `TerrainType` enum
- adjust `SquadOrderSystem` to keep the preferred formation
- implement `FormationAdaptationSystem` to switch formations in narrow spaces

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c2d5e127c8332a2f6e71ebba7f5ab