### PR TITLE
Implement UnitSpacingSystem

### DIFF
--- a/Assets/Scripts/Squads/UnitLocalTargetComponent.cs
+++ b/Assets/Scripts/Squads/UnitLocalTargetComponent.cs
@@ -1,0 +1,12 @@
+using Unity.Entities;
+using Unity.Mathematics;
+
+/// <summary>
+/// Desired local position of a unit inside its squad formation. Other
+/// systems move the unit towards this target.
+/// </summary>
+public struct UnitLocalTargetComponent : IComponentData
+{
+    /// <summary>Local position that the unit should aim to occupy.</summary>
+    public float3 targetPosition;
+}

--- a/Assets/Scripts/Squads/UnitSpacingComponent.cs
+++ b/Assets/Scripts/Squads/UnitSpacingComponent.cs
@@ -1,0 +1,14 @@
+using Unity.Entities;
+
+/// <summary>
+/// Parameters that control how much space a unit maintains from its
+/// allies inside the squad.
+/// </summary>
+public struct UnitSpacingComponent : IComponentData
+{
+    /// <summary>Minimum desired distance to other units.</summary>
+    public float minDistance;
+
+    /// <summary>Strength of the repelling force applied when overlapping.</summary>
+    public float repelForce;
+}

--- a/Assets/Scripts/Squads/UnitSpacingSystem.cs
+++ b/Assets/Scripts/Squads/UnitSpacingSystem.cs
@@ -1,0 +1,70 @@
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+/// <summary>
+/// Adjusts local target positions of squad units so they keep a minimum
+/// separation from each other and avoid visual overlap.
+/// </summary>
+[UpdateInGroup(typeof(SimulationSystemGroup))]
+[UpdateAfter(typeof(FormationSystem))]
+public partial class UnitSpacingSystem : SystemBase
+{
+    protected override void OnUpdate()
+    {
+        const float maxPush = 0.5f;
+
+        var localTargetLookup = GetComponentLookup<UnitLocalTargetComponent>();
+        var spacingLookup = GetComponentLookup<UnitSpacingComponent>(true);
+        var transformLookup = GetComponentLookup<LocalTransform>(true);
+
+        foreach (var units in SystemAPI.Query<DynamicBuffer<SquadUnitElement>>())
+        {
+            int count = units.Length;
+            for (int i = 0; i < count; i++)
+            {
+                Entity entityA = units[i].Value;
+                if (!localTargetLookup.HasComponent(entityA) ||
+                    !spacingLookup.HasComponent(entityA) ||
+                    !transformLookup.HasComponent(entityA))
+                    continue;
+
+                float3 posA = transformLookup[entityA].Position;
+                var spacing = spacingLookup[entityA];
+                float3 offset = float3.zero;
+
+                for (int j = 0; j < count; j++)
+                {
+                    if (i == j) continue;
+
+                    Entity entityB = units[j].Value;
+                    if (!transformLookup.HasComponent(entityB))
+                        continue;
+
+                    float3 posB = transformLookup[entityB].Position;
+                    float3 diff = posA - posB;
+                    float distSq = math.lengthsq(diff);
+                    float minDistSq = spacing.minDistance * spacing.minDistance;
+                    if (distSq < minDistSq && distSq > 1e-6f)
+                    {
+                        float dist = math.sqrt(distSq);
+                        float3 dir = diff / dist;
+                        float push = (spacing.minDistance - dist) * spacing.repelForce;
+                        offset += dir * push;
+                    }
+                }
+
+                if (!math.all(offset == float3.zero))
+                {
+                    float len = math.length(offset);
+                    if (len > maxPush)
+                        offset = offset * (maxPush / len);
+
+                    var target = localTargetLookup[entityA];
+                    target.targetPosition += offset;
+                    localTargetLookup[entityA] = target;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `UnitLocalTargetComponent` for local desired positions
- add `UnitSpacingComponent` to define squad spacing parameters
- implement `UnitSpacingSystem` that adjusts unit targets to avoid overlap

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c38c15ce883329a56f0b1992538bc