### PR TITLE
Add critical hits for hero

### DIFF
--- a/Assets/Scripts/Combat/UnitAttackSystem.cs
+++ b/Assets/Scripts/Combat/UnitAttackSystem.cs
@@ -63,7 +63,7 @@ public partial class UnitAttackSystem : SystemBase
             {
                 if (!SystemAPI.HasComponent<PendingDamageEvent>(entity))
                 {
-                    bool crit = UnityEngine.Random.value <= 0.1f;
+                    bool crit = UnityEngine.Random.value <= weapon.ValueRO.criticalChance;
                     SystemAPI.AddComponent(entity, new PendingDamageEvent
                     {
                         target = target,

--- a/Assets/Scripts/Combat/UnitWeaponComponent.cs
+++ b/Assets/Scripts/Combat/UnitWeaponComponent.cs
@@ -13,4 +13,10 @@ public struct UnitWeaponComponent : IComponentData
 
     /// <summary>Time between consecutive attacks.</summary>
     public float attackInterval;
+
+    /// <summary>
+    /// Probability of landing a critical hit. Value between 0 and 1.
+    /// Used by both units and the hero.
+    /// </summary>
+    public float criticalChance;
 }

--- a/Assets/Scripts/Combat/WeaponColliderComponent.cs
+++ b/Assets/Scripts/Combat/WeaponColliderComponent.cs
@@ -1,0 +1,15 @@
+using Unity.Entities;
+
+/// <summary>
+/// Component placed on a weapon collider entity. It is enabled only during
+/// the impact frames of an attack animation so that collisions can be
+/// detected and damage events generated.
+/// </summary>
+public struct WeaponColliderComponent : IComponentData
+{
+    /// <summary>Owner entity that initiated the attack.</summary>
+    public Entity owner;
+
+    /// <summary>True while the collider should detect hits.</summary>
+    public bool isActive;
+}

--- a/Assets/Scripts/Hero/HeroAnimationComponent.cs
+++ b/Assets/Scripts/Hero/HeroAnimationComponent.cs
@@ -1,0 +1,11 @@
+using Unity.Entities;
+
+/// <summary>
+/// Holds animation triggers for the hero. Systems controlling visuals
+/// can read these values to play the correct animations.
+/// </summary>
+public struct HeroAnimationComponent : IComponentData
+{
+    /// <summary>Set when a melee attack animation should play.</summary>
+    public bool triggerAttack;
+}

--- a/Assets/Scripts/Hero/HeroAttackSystem.cs
+++ b/Assets/Scripts/Hero/HeroAttackSystem.cs
@@ -1,0 +1,95 @@
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Physics;
+using Unity.Transforms;
+using UnityEngine;
+
+/// <summary>
+/// System that handles hero attack input, manages cooldowns and enables the
+/// weapon collider during the impact frames. When a collision is detected a
+/// <see cref="PendingDamageEvent"/> is created on the hero.
+/// </summary>
+[UpdateInGroup(typeof(SimulationSystemGroup))]
+public partial class HeroAttackSystem : SystemBase
+{
+    protected override void OnUpdate()
+    {
+        float deltaTime = SystemAPI.Time.DeltaTime;
+        var physicsWorld = SystemAPI.GetSingleton<PhysicsWorldSingleton>().CollisionWorld;
+
+        // Process attack input and start animations
+        foreach (var (input, combat, stamina, life, anim, entity) in
+                 SystemAPI.Query<RefRO<HeroInputComponent>,
+                                 RefRW<HeroCombatComponent>,
+                                 RefRW<StaminaComponent>,
+                                 RefRO<HeroLifeComponent>,
+                                 RefRW<HeroAnimationComponent>>()
+                        .WithAll<IsLocalPlayer>()
+                        .WithEntityAccess())
+        {
+            if (!life.ValueRO.isAlive)
+                continue;
+
+            var c = combat.ValueRW;
+            c.attackCooldown = math.max(0f, c.attackCooldown - deltaTime);
+
+            if (input.ValueRO.isAttacking && !c.isAttacking && c.attackCooldown <= 0f &&
+                !stamina.ValueRO.isExhausted && stamina.ValueRO.currentStamina >= 15f)
+            {
+                c.isAttacking = true;
+                c.attackCooldown = 0.7f; // default cooldown
+                anim.ValueRW.triggerAttack = true;
+                stamina.ValueRW.currentStamina -= 15f;
+
+                if (SystemAPI.Exists(c.activeWeapon) &&
+                    SystemAPI.HasComponent<WeaponColliderComponent>(c.activeWeapon))
+                {
+                    var weapon = SystemAPI.GetComponentRW<WeaponColliderComponent>(c.activeWeapon);
+                    weapon.ValueRW.owner = entity;
+                    weapon.ValueRW.isActive = true;
+                }
+            }
+
+            combat.ValueRW = c;
+        }
+
+        // Check for collisions while weapon colliders are active
+        foreach (var (weapon, collider, transform, weaponData) in
+                 SystemAPI.Query<RefRW<WeaponColliderComponent>,
+                                 RefRO<PhysicsCollider>,
+                                 RefRO<LocalTransform>,
+                                 RefRO<UnitWeaponComponent>>()
+                        .WithEntityAccess())
+        {
+            if (!weapon.ValueRO.isActive)
+                continue;
+
+            var aabb = collider.ValueRO.CalculateAabb(new RigidTransform(transform.ValueRO.Rotation, transform.ValueRO.Position));
+            using var hits = new NativeList<int>(Allocator.Temp);
+            physicsWorld.OverlapAabb(aabb, ref hits, CollisionFilter.Default);
+
+            for (int i = 0; i < hits.Length; i++)
+            {
+                Entity hitEntity = SystemAPI.GetSingleton<PhysicsWorldSingleton>().PhysicsWorld.Bodies[hits[i]].Entity;
+                if (hitEntity == weapon.ValueRO.owner)
+                    continue;
+
+                if (!SystemAPI.HasComponent<PendingDamageEvent>(weapon.ValueRO.owner))
+                {
+                    bool crit = UnityEngine.Random.value <= weaponData.ValueRO.criticalChance;
+                    SystemAPI.AddComponent(weapon.ValueRO.owner, new PendingDamageEvent
+                    {
+                        target = hitEntity,
+                        damageProfile = weaponData.ValueRO.damageProfile,
+                        category = crit ? DamageCategory.Critical : DamageCategory.Normal,
+                        multiplier = crit ? 1.5f : 1f
+                    });
+                }
+            }
+
+            weapon.ValueRW.isActive = false;
+        }
+    }
+}

--- a/Assets/Scripts/Hero/HeroCombatComponent.cs
+++ b/Assets/Scripts/Hero/HeroCombatComponent.cs
@@ -1,0 +1,17 @@
+using Unity.Entities;
+
+/// <summary>
+/// Stores combat related data for the hero such as the equipped weapon
+/// and attack cooldown state.
+/// </summary>
+public struct HeroCombatComponent : IComponentData
+{
+    /// <summary>Entity representing the currently active weapon.</summary>
+    public Entity activeWeapon;
+
+    /// <summary>Cooldown time remaining before the next attack.</summary>
+    public float attackCooldown;
+
+    /// <summary>Set when the hero is in the middle of an attack animation.</summary>
+    public bool isAttacking;
+}

--- a/Docs/TDD.md
+++ b/Docs/TDD.md
@@ -353,6 +353,7 @@ El comportamiento es **grupal**, pero con **unidad mínima de decisión** en cad
 - `UnitAttackSystem`:
     - Verifica cooldowns
     - Ejecuta animaciones de ataque si tiene target
+    - Usa `criticalChance` del arma para aplicar golpes críticos de 1.5x
 
 ---
 
@@ -655,6 +656,7 @@ HeroAttackSystem
 - Valida cooldown y stamina
 - Reproduce animación correcta
 - Activa collider de arma mediante Animation Events
+- Genera golpes críticos con multiplicador 1.5x según `criticalChance` del arma
 ```
 
 ```csharp
@@ -691,6 +693,7 @@ SquadCombatComponent (IComponentData)
 ```csharp
 UnitWeaponComponent (IComponentData)
 - damageProfile: Entity (referencia a ScriptableObject con daño, tipo, penetración)
+- criticalChance: float (probabilidad de crítico para héroe y unidades)
 ```
 
 ```csharp


### PR DESCRIPTION
## Summary
- give `UnitWeaponComponent` a `criticalChance` field
- let hero and unit attacks roll criticals based on that chance
- document critical hit usage in `TDD`

## Testing
- `dotnet build prototipo_curado.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c4aa4042c8332ba7cb138fccb448d