### PR TITLE
Implement DamageCalculationSystem with resistances

### DIFF
--- a/Assets/Scripts/Combat/IsDeadComponent.cs
+++ b/Assets/Scripts/Combat/IsDeadComponent.cs
@@ -1,0 +1,8 @@
+using Unity.Entities;
+
+/// <summary>
+/// Tag component added when an entity dies.
+/// </summary>
+public struct IsDeadComponent : IComponentData
+{
+}

--- a/Assets/Scripts/Combat/PendingDamageEvent.cs
+++ b/Assets/Scripts/Combat/PendingDamageEvent.cs
@@ -9,8 +9,14 @@ public struct PendingDamageEvent : IComponentData
     /// <summary>Entity that will receive the damage.</summary>
     public Entity target;
 
+    /// <summary>Entity that originated the damage.</summary>
+    public Entity damageSource;
+
     /// <summary>Damage profile to apply.</summary>
     public Entity damageProfile;
+
+    /// <summary>Team of the source entity to check friendly fire.</summary>
+    public Team sourceTeam;
 
     /// <summary>Visual category for popup effects.</summary>
     public DamageCategory category;

--- a/Assets/Scripts/Combat/SquadAttackSystem.cs
+++ b/Assets/Scripts/Combat/SquadAttackSystem.cs
@@ -80,10 +80,16 @@ public partial class SquadAttackSystem : SystemBase
                         !SystemAPI.HasComponent<PendingDamageEvent>(unit))
                     {
                         bool crit = Random.value <= weapon.criticalChance;
+                        Team team = Team.None;
+                        if (SystemAPI.HasComponent<TeamComponent>(unit))
+                            team = SystemAPI.GetComponent<TeamComponent>(unit).value;
+
                         SystemAPI.AddComponent(unit, new PendingDamageEvent
                         {
                             target = chosen,
+                            damageSource = unit,
                             damageProfile = weapon.damageProfile,
+                            sourceTeam = team,
                             category = crit ? DamageCategory.Critical : DamageCategory.Normal,
                             multiplier = crit ? 1.5f : 1f
                         });

--- a/Assets/Scripts/Combat/Team.cs
+++ b/Assets/Scripts/Combat/Team.cs
@@ -1,0 +1,9 @@
+/// <summary>
+/// Identifies the faction an entity belongs to.
+/// </summary>
+public enum Team
+{
+    None,
+    TeamA,
+    TeamB
+}

--- a/Assets/Scripts/Combat/TeamComponent.cs
+++ b/Assets/Scripts/Combat/TeamComponent.cs
@@ -1,0 +1,10 @@
+using Unity.Entities;
+
+/// <summary>
+/// Stores team information for an entity.
+/// </summary>
+public struct TeamComponent : IComponentData
+{
+    /// <summary>Team this entity belongs to.</summary>
+    public Team value;
+}

--- a/Assets/Scripts/Combat/UnitAttackSystem.cs
+++ b/Assets/Scripts/Combat/UnitAttackSystem.cs
@@ -64,10 +64,16 @@ public partial class UnitAttackSystem : SystemBase
                 if (!SystemAPI.HasComponent<PendingDamageEvent>(entity))
                 {
                     bool crit = UnityEngine.Random.value <= weapon.ValueRO.criticalChance;
+                    Team team = Team.None;
+                    if (SystemAPI.HasComponent<TeamComponent>(entity))
+                        team = SystemAPI.GetComponent<TeamComponent>(entity).value;
+
                     SystemAPI.AddComponent(entity, new PendingDamageEvent
                     {
                         target = target,
+                        damageSource = entity,
                         damageProfile = weapon.ValueRO.damageProfile,
+                        sourceTeam = team,
                         category = crit ? DamageCategory.Critical : DamageCategory.Normal,
                         multiplier = crit ? 1.5f : 1f
                     });

--- a/Assets/Scripts/Hero/HeroAttackSystem.cs
+++ b/Assets/Scripts/Hero/HeroAttackSystem.cs
@@ -79,10 +79,16 @@ public partial class HeroAttackSystem : SystemBase
                 if (!SystemAPI.HasComponent<PendingDamageEvent>(weapon.ValueRO.owner))
                 {
                     bool crit = UnityEngine.Random.value <= weaponData.ValueRO.criticalChance;
+                    Team team = Team.None;
+                    if (SystemAPI.HasComponent<TeamComponent>(weapon.ValueRO.owner))
+                        team = SystemAPI.GetComponent<TeamComponent>(weapon.ValueRO.owner).value;
+
                     SystemAPI.AddComponent(weapon.ValueRO.owner, new PendingDamageEvent
                     {
                         target = hitEntity,
+                        damageSource = weapon.ValueRO.owner,
                         damageProfile = weaponData.ValueRO.damageProfile,
+                        sourceTeam = team,
                         category = crit ? DamageCategory.Critical : DamageCategory.Normal,
                         multiplier = crit ? 1.5f : 1f
                     });


### PR DESCRIPTION
## Summary
- implement core damage logic honoring defenses and penetration
- add teams to avoid friendly fire and track kill state
- update attack systems to fill extended damage events
- add Team, TeamComponent and IsDeadComponent

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5dffe9748332a397bd8376165cd6