### PR TITLE
Implement UnitFollowFormationSystem

### DIFF
--- a/Assets/Scripts/Squads/UnitFollowFormationSystem.cs
+++ b/Assets/Scripts/Squads/UnitFollowFormationSystem.cs
@@ -1,0 +1,66 @@
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+/// <summary>
+/// Moves each unit of a squad towards its assigned formation slot relative to
+/// the squad leader.
+/// </summary>
+[UpdateInGroup(typeof(SimulationSystemGroup))]
+[UpdateAfter(typeof(FormationSystem))]
+public partial class UnitFollowFormationSystem : SystemBase
+{
+    protected override void OnUpdate()
+    {
+        const float moveSpeed = 5f;
+        const float stoppingDistanceSq = 0.04f; // ~0.2m
+
+        float dt = SystemAPI.Time.DeltaTime;
+
+        var slotLookup = GetComponentLookup<UnitFormationSlotComponent>(true);
+        var targetLookup = GetComponentLookup<UnitLocalTargetComponent>();
+        var transformLookup = GetComponentLookup<LocalTransform>();
+
+        foreach (var units in SystemAPI.Query<DynamicBuffer<SquadUnitElement>>())
+        {
+            if (units.Length == 0)
+                continue;
+
+            Entity leader = units[0].Value;
+            if (!transformLookup.HasComponent(leader))
+                continue;
+
+            float3 leaderPos = transformLookup[leader].Position;
+
+            for (int i = 0; i < units.Length; i++)
+            {
+                Entity unit = units[i].Value;
+                if (!slotLookup.HasComponent(unit) ||
+                    !transformLookup.HasComponent(unit))
+                    continue;
+
+                float3 desired = leaderPos + slotLookup[unit].relativeOffset;
+                float3 current = transformLookup[unit].Position;
+                float3 diff = desired - current;
+                float distSq = math.lengthsq(diff);
+                if (distSq > stoppingDistanceSq)
+                {
+                    float3 step = math.normalizesafe(diff) * moveSpeed * dt;
+                    if (math.lengthsq(step) > distSq)
+                        step = diff;
+                    current += step;
+                    var t = transformLookup[unit];
+                    t.Position = current;
+                    transformLookup[unit] = t;
+                }
+
+                if (targetLookup.HasComponent(unit))
+                {
+                    var target = targetLookup[unit];
+                    target.targetPosition = desired;
+                    targetLookup[unit] = target;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Squads/UnitFormationSlotComponent.cs
+++ b/Assets/Scripts/Squads/UnitFormationSlotComponent.cs
@@ -1,0 +1,16 @@
+using Unity.Entities;
+using Unity.Mathematics;
+
+/// <summary>
+/// Assigned formation slot for a unit. The <see cref="relativeOffset"/> is
+/// relative to the squad leader and indicates where the unit should be
+/// positioned inside the formation.
+/// </summary>
+public struct UnitFormationSlotComponent : IComponentData
+{
+    /// <summary>Offset from the leader in local squad space.</summary>
+    public float3 relativeOffset;
+
+    /// <summary>Index of the slot within the formation pattern.</summary>
+    public int slotIndex;
+}


### PR DESCRIPTION
## Summary
- add `UnitFormationSlotComponent` to hold formation offsets
- implement `UnitFollowFormationSystem` that moves each unit towards its slot

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c677884408332a967a6db3b2968ca