### PR TITLE
Implement persistent DataContainer singleton

### DIFF
--- a/Assets/Scripts/Shared/DataContainerComponent.cs
+++ b/Assets/Scripts/Shared/DataContainerComponent.cs
@@ -1,0 +1,23 @@
+using Unity.Collections;
+using Unity.Entities;
+
+/// <summary>
+/// Stores player selection information that must persist across gameplay scenes.
+/// </summary>
+public struct DataContainerComponent : IComponentData
+{
+    /// <summary>Name chosen by the local player.</summary>
+    public FixedString64Bytes playerName;
+
+    /// <summary>Index of the squad currently selected.</summary>
+    public int selectedSquad;
+
+    /// <summary>List of perk identifiers selected by the player.</summary>
+    public FixedList32Bytes<int> selectedPerks;
+
+    /// <summary>Team identifier for this player.</summary>
+    public int playerTeam;
+
+    /// <summary>True when the player finished setting up and is ready.</summary>
+    public bool isReady;
+}

--- a/Assets/Scripts/Shared/DataContainerSystem.cs
+++ b/Assets/Scripts/Shared/DataContainerSystem.cs
@@ -1,0 +1,34 @@
+using Unity.Collections;
+using Unity.Entities;
+
+/// <summary>
+/// Ensures a singleton <see cref="DataContainerComponent"/> exists and persists
+/// between gameplay scenes.
+/// </summary>
+[UpdateInGroup(typeof(InitializationSystemGroup))]
+public partial class DataContainerSystem : SystemBase
+{
+    protected override void OnCreate()
+    {
+        base.OnCreate();
+
+        if (!SystemAPI.TryGetSingletonEntity<DataContainerComponent>(out _))
+        {
+            var em = World.DefaultGameObjectInjectionWorld.EntityManager;
+            Entity entity = em.CreateEntity(typeof(DataContainerComponent));
+            em.SetComponentData(entity, new DataContainerComponent
+            {
+                playerName = default,
+                selectedSquad = -1,
+                selectedPerks = default,
+                playerTeam = 0,
+                isReady = false
+            });
+        }
+    }
+
+    protected override void OnUpdate()
+    {
+        // This system only holds persistent data; no per-frame logic required.
+    }
+}


### PR DESCRIPTION
## Summary
- add `DataContainerComponent` storing player info across scenes
- introduce `DataContainerSystem` that spawns a persistent singleton entity

## Testing
- `dotnet build -v minimal` *(fails: dotnet not installed)*


------
https://chatgpt.com/codex/tasks/task_e_685c6ee7e7108332bb3d26e591062867