### PR TITLE
Implement basic async scene loading

### DIFF
--- a/Assets/Scripts/AsyncSceneLoader.cs
+++ b/Assets/Scripts/AsyncSceneLoader.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections;
+using System.Reflection;
+using Unity.Entities;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+/// <summary>
+/// Utility to load Unity scenes asynchronously and update the current
+/// <see cref="GameStateComponent"/> with the target <see cref="GamePhase"/>.
+/// </summary>
+public class AsyncSceneLoader : MonoBehaviour
+{
+    static AsyncSceneLoader _instance;
+
+    [SerializeField]
+    GameObject _loadingScreen;
+
+    void Awake()
+    {
+        if (_instance != null && _instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        _instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    /// <summary>
+    /// Loads the given scene and sets the target game phase once loading is
+    /// complete.
+    /// </summary>
+    /// <param name="sceneName">Name of the scene to load.</param>
+    /// <param name="targetPhase">Phase that will be active after the scene loads.</param>
+    public static void LoadScene(string sceneName, GamePhase targetPhase)
+    {
+        if (_instance == null)
+        {
+            var go = new GameObject(nameof(AsyncSceneLoader));
+            _instance = go.AddComponent<AsyncSceneLoader>();
+            DontDestroyOnLoad(go);
+        }
+
+        _instance.StartCoroutine(_instance.LoadSceneRoutine(sceneName, targetPhase));
+    }
+
+    IEnumerator LoadSceneRoutine(string sceneName, GamePhase targetPhase)
+    {
+        if (_loadingScreen != null)
+            _loadingScreen.SetActive(true);
+
+        AsyncOperation op = SceneManager.LoadSceneAsync(sceneName);
+        while (!op.isDone)
+            yield return null;
+
+        if (_loadingScreen != null)
+            _loadingScreen.SetActive(false);
+
+        var em = World.DefaultGameObjectInjectionWorld.EntityManager;
+        if (!SystemAPI.TryGetSingletonEntity<GameStateComponent>(out Entity stateEntity))
+        {
+            stateEntity = em.CreateEntity(typeof(GameStateComponent));
+        }
+        em.SetComponentData(stateEntity, new GameStateComponent { currentPhase = targetPhase });
+
+        // Optional integration with SceneFlowManager using reflection
+        Type managerType = Type.GetType("SceneFlowManager");
+        if (managerType != null)
+        {
+            UnityEngine.Object manager = FindObjectOfType(managerType);
+            if (manager != null)
+            {
+                MethodInfo method = managerType.GetMethod("OnPhaseChanged", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                if (method != null)
+                {
+                    method.Invoke(manager, new object[] { targetPhase });
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Shared/GamePhase.cs
+++ b/Assets/Scripts/Shared/GamePhase.cs
@@ -1,0 +1,9 @@
+public enum GamePhase
+{
+    Login,
+    Feudo,
+    Barracon,
+    Preparacion,
+    Combate,
+    PostPartida
+}

--- a/Assets/Scripts/Shared/GameStateComponent.cs
+++ b/Assets/Scripts/Shared/GameStateComponent.cs
@@ -1,0 +1,12 @@
+using Unity.Entities;
+
+/// <summary>
+/// Holds the current <see cref="GamePhase"/> of the game.
+/// </summary>
+public struct GameStateComponent : IComponentData
+{
+    /// <summary>
+    /// Phase the game is currently in.
+    /// </summary>
+    public GamePhase currentPhase;
+}

--- a/Assets/Scripts/Shared/GameStateSystem.cs
+++ b/Assets/Scripts/Shared/GameStateSystem.cs
@@ -1,0 +1,29 @@
+using Unity.Entities;
+
+/// <summary>
+/// Ensures a singleton <see cref="GameStateComponent"/> exists and persists
+/// between gameplay scenes.
+/// </summary>
+[UpdateInGroup(typeof(InitializationSystemGroup))]
+public partial class GameStateSystem : SystemBase
+{
+    protected override void OnCreate()
+    {
+        base.OnCreate();
+
+        if (!SystemAPI.TryGetSingletonEntity<GameStateComponent>(out _))
+        {
+            var em = World.DefaultGameObjectInjectionWorld.EntityManager;
+            Entity entity = em.CreateEntity(typeof(GameStateComponent));
+            em.SetComponentData(entity, new GameStateComponent
+            {
+                currentPhase = GamePhase.Login
+            });
+        }
+    }
+
+    protected override void OnUpdate()
+    {
+        // No per-frame logic required.
+    }
+}


### PR DESCRIPTION
## Summary
- add `GamePhase` enum for known game phases
- provide a `GameStateComponent` and `GameStateSystem` singleton
- implement `AsyncSceneLoader` MonoBehaviour for async scene transitions

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c7043880883328de22c9f2ad594fb