### PR TITLE
Implement match state controller

### DIFF
--- a/Assets/Scripts/Map/CaptureZoneTriggerSystem.cs
+++ b/Assets/Scripts/Map/CaptureZoneTriggerSystem.cs
@@ -97,7 +97,7 @@ public partial class CaptureZoneTriggerSystem : SystemBase
                     SystemAPI.TryGetSingletonEntity<GameStateComponent>(out var stateEntity))
                 {
                     var state = SystemAPI.GetComponentRW<GameStateComponent>(stateEntity);
-                    state.ValueRW.currentPhase = GamePhase.PostGame;
+                    state.ValueRW.currentPhase = GamePhase.PostPartida;
                 }
             }
         }

--- a/Assets/Scripts/Shared/GameStateChangeEvent.cs
+++ b/Assets/Scripts/Shared/GameStateChangeEvent.cs
@@ -1,0 +1,11 @@
+using Unity.Entities;
+
+/// <summary>
+/// Event emitted when the match state changes. Systems can listen
+/// for this component to react to state transitions.
+/// </summary>
+public struct GameStateChangeEvent : IComponentData
+{
+    /// <summary>The new state that became active.</summary>
+    public MatchState newState;
+}

--- a/Assets/Scripts/Shared/MatchControllerSystem.cs
+++ b/Assets/Scripts/Shared/MatchControllerSystem.cs
@@ -1,0 +1,78 @@
+using Unity.Collections;
+using Unity.Entities;
+
+/// <summary>
+/// Server-side system that controls the flow of a match.
+/// It advances <see cref="MatchStateComponent"/> automatically and
+/// broadcasts <see cref="GameStateChangeEvent"/> on transitions.
+/// </summary>
+[UpdateInGroup(typeof(SimulationSystemGroup))]
+public partial class MatchControllerSystem : SystemBase
+{
+    protected override void OnCreate()
+    {
+        base.OnCreate();
+
+        if (!SystemAPI.TryGetSingletonEntity<MatchStateComponent>(out _))
+        {
+            var em = World.DefaultGameObjectInjectionWorld.EntityManager;
+            Entity entity = em.CreateEntity(typeof(MatchStateComponent));
+            em.SetComponentData(entity, new MatchStateComponent
+            {
+                currentState = MatchState.WaitingForPlayers,
+                stateTimer = 0f,
+                playersReady = 0,
+                maxPlayers = 2,
+                victoryConditionMet = false
+            });
+        }
+    }
+
+    protected override void OnUpdate()
+    {
+        if (!SystemAPI.TryGetSingletonEntity<MatchStateComponent>(out var entity))
+            return;
+
+        var state = SystemAPI.GetComponentRW<MatchStateComponent>(entity);
+        float dt = SystemAPI.Time.DeltaTime;
+        var ecb = new EntityCommandBuffer(Allocator.Temp);
+
+        state.ValueRW.stateTimer -= dt;
+
+        switch (state.ValueRO.currentState)
+        {
+            case MatchState.WaitingForPlayers:
+                if (state.ValueRO.playersReady >= state.ValueRO.maxPlayers)
+                    Transition(ref state, MatchState.PreparationPhase, ref ecb);
+                break;
+
+            case MatchState.PreparationPhase:
+                if (state.ValueRO.stateTimer <= 0f)
+                    Transition(ref state, MatchState.LoadingMap, ref ecb);
+                break;
+
+            case MatchState.LoadingMap:
+                if (state.ValueRO.playersReady >= state.ValueRO.maxPlayers)
+                    Transition(ref state, MatchState.InBattle, ref ecb);
+                break;
+
+            case MatchState.InBattle:
+                if (state.ValueRO.victoryConditionMet)
+                    Transition(ref state, MatchState.EndMatch, ref ecb);
+                break;
+        }
+
+        ecb.Playback(EntityManager);
+        ecb.Dispose();
+    }
+
+    void Transition(ref RefRW<MatchStateComponent> state, MatchState newState,
+                     ref EntityCommandBuffer ecb)
+    {
+        state.ValueRW.currentState = newState;
+        state.ValueRW.stateTimer = 0f;
+
+        Entity evt = ecb.CreateEntity();
+        ecb.AddComponent(evt, new GameStateChangeEvent { newState = newState });
+    }
+}

--- a/Assets/Scripts/Shared/MatchState.cs
+++ b/Assets/Scripts/Shared/MatchState.cs
@@ -1,0 +1,8 @@
+public enum MatchState
+{
+    WaitingForPlayers,
+    PreparationPhase,
+    LoadingMap,
+    InBattle,
+    EndMatch
+}

--- a/Assets/Scripts/Shared/MatchStateComponent.cs
+++ b/Assets/Scripts/Shared/MatchStateComponent.cs
@@ -1,0 +1,23 @@
+using Unity.Entities;
+
+/// <summary>
+/// Component holding the current <see cref="MatchState"/> of the match
+/// along with transition related data.
+/// </summary>
+public struct MatchStateComponent : IComponentData
+{
+    /// <summary>Current match state.</summary>
+    public MatchState currentState;
+
+    /// <summary>Timer used for countdowns in some states.</summary>
+    public float stateTimer;
+
+    /// <summary>Number of players that have confirmed readiness.</summary>
+    public int playersReady;
+
+    /// <summary>Maximum number of players in the match.</summary>
+    public int maxPlayers;
+
+    /// <summary>Flag set when victory conditions are achieved.</summary>
+    public bool victoryConditionMet;
+}


### PR DESCRIPTION
## Summary
- fix capture zone logic to transition to PostPartida state
- add a match state machine with `MatchControllerSystem`
- emit `GameStateChangeEvent` on state change
- introduce `MatchStateComponent` and `MatchState` enum

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d2241f4108332913518ea8682d5da