### PR TITLE
Implement Loadout selection UI

### DIFF
--- a/Assets/Scripts/Shared/DataContainerComponent.cs
+++ b/Assets/Scripts/Shared/DataContainerComponent.cs
@@ -9,11 +9,17 @@ public struct DataContainerComponent : IComponentData
     /// <summary>Name chosen by the local player.</summary>
     public FixedString64Bytes playerName;
 
-    /// <summary>Index of the squad currently selected.</summary>
-    public int selectedSquad;
+    /// <summary>Identifier of the loadout selected for the match.</summary>
+    public int selectedLoadoutID;
+
+    /// <summary>List of squad identifiers of the active loadout.</summary>
+    public FixedList64Bytes<int> selectedSquads;
 
     /// <summary>List of perk identifiers selected by the player.</summary>
     public FixedList32Bytes<int> selectedPerks;
+
+    /// <summary>Total leadership used by the selected loadout.</summary>
+    public int totalLeadershipUsed;
 
     /// <summary>Team identifier for this player.</summary>
     public int playerTeam;

--- a/Assets/Scripts/Shared/DataContainerSystem.cs
+++ b/Assets/Scripts/Shared/DataContainerSystem.cs
@@ -19,8 +19,10 @@ public partial class DataContainerSystem : SystemBase
             em.SetComponentData(entity, new DataContainerComponent
             {
                 playerName = default,
-                selectedSquad = -1,
+                selectedLoadoutID = -1,
+                selectedSquads = default,
                 selectedPerks = default,
+                totalLeadershipUsed = 0,
                 playerTeam = 0,
                 isReady = false
             });

--- a/Assets/Scripts/Shared/LocalSaveSystem.cs
+++ b/Assets/Scripts/Shared/LocalSaveSystem.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+/// <summary>
+/// Simple utility that stores and loads player progress in JSON format
+/// under the application's persistent data path.
+/// </summary>
+public static class LocalSaveSystem
+{
+    /// <summary>Container for all player progress data.</summary>
+    [Serializable]
+    public class PlayerProgressData
+    {
+        public List<LoadoutData> loadouts = new();
+    }
+
+    /// <summary>Serializable representation of a loadout.</summary>
+    [Serializable]
+    public class LoadoutData
+    {
+        public int loadoutID;
+        public List<int> squadIDs = new();
+        public List<int> perkIDs = new();
+        public int leadershipUsed;
+    }
+
+    static string FilePath => Path.Combine(Application.persistentDataPath, "save.json");
+
+    /// <summary>Loads the player progress file if it exists.</summary>
+    public static PlayerProgressData LoadGame()
+    {
+        if (!File.Exists(FilePath))
+            return new PlayerProgressData();
+
+        try
+        {
+            string json = File.ReadAllText(FilePath);
+            return JsonUtility.FromJson<PlayerProgressData>(json);
+        }
+        catch
+        {
+            return new PlayerProgressData();
+        }
+    }
+
+    /// <summary>Saves the given progress data to disk.</summary>
+    public static void SaveGame(PlayerProgressData data)
+    {
+        string json = JsonUtility.ToJson(data, true);
+        File.WriteAllText(FilePath, json);
+    }
+}
+

--- a/Assets/Scripts/UI/LoadoutSelectionUI.cs
+++ b/Assets/Scripts/UI/LoadoutSelectionUI.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+using Unity.Entities;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// UI controller used during the Preparation phase to select one of the
+/// previously saved loadouts.
+/// </summary>
+public class LoadoutSelectionUI : MonoBehaviour
+{
+    [System.Serializable]
+    public class LoadoutItem
+    {
+        public Text title;
+        public Text squads;
+        public Text perks;
+        public Text leadership;
+        public Button selectButton;
+
+        public void SetData(LocalSaveSystem.LoadoutData data)
+        {
+            if (title != null)
+                title.text = $"Loadout {data.loadoutID + 1}";
+            if (squads != null)
+                squads.text = string.Join(", ", data.squadIDs);
+            if (perks != null)
+                perks.text = string.Join(", ", data.perkIDs);
+            if (leadership != null)
+                leadership.text = data.leadershipUsed.ToString();
+        }
+    }
+
+    [SerializeField] List<LoadoutItem> _loadouts = new();
+    [SerializeField] Button _confirmButton;
+
+    LocalSaveSystem.PlayerProgressData _progress;
+    int _selectedIndex = -1;
+
+    void Start()
+    {
+        _progress = LocalSaveSystem.LoadGame();
+
+        for (int i = 0; i < _loadouts.Count; i++)
+        {
+            if (i < _progress.loadouts.Count)
+            {
+                var ld = _progress.loadouts[i];
+                _loadouts[i].SetData(ld);
+                int idx = i;
+                if (_loadouts[i].selectButton != null)
+                    _loadouts[i].selectButton.onClick.AddListener(() => SelectLoadout(idx));
+            }
+            else
+            {
+                if (_loadouts[i].selectButton != null)
+                    _loadouts[i].selectButton.interactable = false;
+            }
+        }
+
+        if (_confirmButton != null)
+            _confirmButton.onClick.AddListener(ConfirmSelection);
+    }
+
+    /// <summary>Selects the loadout at the given index.</summary>
+    /// <param name="index">Index of the loadout to activate.</param>
+    public void SelectLoadout(int index)
+    {
+        _selectedIndex = index;
+    }
+
+    /// <summary>Copies the selected loadout into the DataContainer.</summary>
+    void ConfirmSelection()
+    {
+        if (_selectedIndex < 0 || _selectedIndex >= _progress.loadouts.Count)
+            return;
+
+        var em = World.DefaultGameObjectInjectionWorld.EntityManager;
+        if (!SystemAPI.TryGetSingletonEntity<DataContainerComponent>(out var entity))
+            return;
+
+        var container = em.GetComponentData<DataContainerComponent>(entity);
+        var data = _progress.loadouts[_selectedIndex];
+
+        container.selectedLoadoutID = data.loadoutID;
+        container.selectedSquads.Clear();
+        foreach (int id in data.squadIDs)
+            container.selectedSquads.Add(id);
+
+        container.selectedPerks.Clear();
+        foreach (int id in data.perkIDs)
+            container.selectedPerks.Add(id);
+
+        container.totalLeadershipUsed = data.leadershipUsed;
+        container.isReady = true;
+
+        em.SetComponentData(entity, container);
+    }
+}
+


### PR DESCRIPTION
## Summary
- extend `DataContainerComponent` with loadout information
- update `DataContainerSystem` defaults
- add `LocalSaveSystem` for storing player progress locally
- implement `LoadoutSelectionUI` MonoBehaviour to pick a saved loadout

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d2f6c24fc83329622ec425e2d0f10