### PR TITLE
Add spawn selection storage and UI controller

### DIFF
--- a/Assets/Scripts/Hero/HeroSpawnSystem.cs
+++ b/Assets/Scripts/Hero/HeroSpawnSystem.cs
@@ -23,6 +23,9 @@ public partial class HeroSpawnSystem : SystemBase
         {
             if (!spawnData.ValueRO.hasSpawned && life.ValueRO.isAlive)
             {
+                if (SystemAPI.TryGetSingleton<DataContainerComponent>(out var data))
+                    spawnData.ValueRW.spawnId = data.selectedSpawnID;
+
                 bool found = false;
                 SpawnPointComponent selected = default;
 

--- a/Assets/Scripts/Hero/SpawnSelectionSystem.cs
+++ b/Assets/Scripts/Hero/SpawnSelectionSystem.cs
@@ -18,6 +18,13 @@ public partial class SpawnSelectionSystem : SystemBase
                      .WithAll<IsLocalPlayer>()
                      .WithEntityAccess())
         {
+            if (SystemAPI.TryGetSingletonEntity<DataContainerComponent>(out var containerEntity))
+            {
+                var data = EntityManager.GetComponentData<DataContainerComponent>(containerEntity);
+                data.selectedSpawnID = request.ValueRO.spawnId;
+                EntityManager.SetComponentData(containerEntity, data);
+            }
+
             spawn.ValueRW.spawnId = request.ValueRO.spawnId;
             spawn.ValueRW.hasSpawned = false;
             ecb.RemoveComponent<SpawnSelectionRequest>(entity);

--- a/Assets/Scripts/Shared/DataContainerComponent.cs
+++ b/Assets/Scripts/Shared/DataContainerComponent.cs
@@ -21,6 +21,9 @@ public struct DataContainerComponent : IComponentData
     /// <summary>Total leadership used by the selected loadout.</summary>
     public int totalLeadershipUsed;
 
+    /// <summary>Identifier of the spawn point chosen during preparation.</summary>
+    public int selectedSpawnID;
+
     /// <summary>Team identifier for this player.</summary>
     public int playerTeam;
 

--- a/Assets/Scripts/Shared/DataContainerSystem.cs
+++ b/Assets/Scripts/Shared/DataContainerSystem.cs
@@ -23,6 +23,7 @@ public partial class DataContainerSystem : SystemBase
                 selectedSquads = default,
                 selectedPerks = default,
                 totalLeadershipUsed = 0,
+                selectedSpawnID = -1,
                 playerTeam = 0,
                 isReady = false
             });

--- a/Assets/Scripts/UI/MapUIController.cs
+++ b/Assets/Scripts/UI/MapUIController.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using Unity.Collections;
+using Unity.Entities;
+using UnityEngine;
+
+/// <summary>
+/// Displays available spawn points on the minimap and forwards the
+/// player's selection into the DataContainer.
+/// </summary>
+public class MapUIController : MonoBehaviour
+{
+    [SerializeField] RectTransform _spawnContainer;
+    [SerializeField] SpawnIcon _spawnIconPrefab;
+
+    readonly List<SpawnIcon> _icons = new();
+
+    void Start()
+    {
+        var em = World.DefaultGameObjectInjectionWorld.EntityManager;
+
+        if (!SystemAPI.TryGetSingletonEntity<DataContainerComponent>(out var dataEntity))
+            return;
+
+        var data = em.GetComponentData<DataContainerComponent>(dataEntity);
+        var query = em.CreateEntityQuery(ComponentType.ReadOnly<SpawnPointComponent>());
+        using NativeArray<SpawnPointComponent> points = query.ToComponentDataArray<SpawnPointComponent>(Allocator.Temp);
+
+        foreach (var sp in points)
+        {
+            if (sp.teamID != data.playerTeam || !sp.isActive)
+                continue;
+
+            if (_spawnIconPrefab != null && _spawnContainer != null)
+            {
+                var icon = Instantiate(_spawnIconPrefab, _spawnContainer);
+                icon.Initialize(sp.spawnID, this);
+                _icons.Add(icon);
+            }
+        }
+    }
+
+    /// <summary>Selects the given spawn point.</summary>
+    /// <param name="spawnId">Identifier of the spawn point.</param>
+    public void SelectSpawn(int spawnId)
+    {
+        var em = World.DefaultGameObjectInjectionWorld.EntityManager;
+
+        if (SystemAPI.TryGetSingletonEntity<DataContainerComponent>(out var dataEntity))
+        {
+            var data = em.GetComponentData<DataContainerComponent>(dataEntity);
+            data.selectedSpawnID = spawnId;
+            em.SetComponentData(dataEntity, data);
+        }
+
+        var heroQuery = em.CreateEntityQuery(ComponentType.ReadOnly<HeroSpawnComponent>(),
+                                             ComponentType.ReadOnly<IsLocalPlayer>());
+        if (!heroQuery.IsEmptyIgnoreFilter)
+        {
+            Entity hero = heroQuery.GetSingletonEntity();
+            if (em.HasComponent<SpawnSelectionRequest>(hero))
+                em.SetComponentData(hero, new SpawnSelectionRequest { spawnId = spawnId });
+            else
+                em.AddComponent(hero, new SpawnSelectionRequest { spawnId = spawnId });
+        }
+    }
+}

--- a/Assets/Scripts/UI/SpawnIcon.cs
+++ b/Assets/Scripts/UI/SpawnIcon.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Simple helper attached to spawn point buttons on the minimap.
+/// </summary>
+public class SpawnIcon : MonoBehaviour
+{
+    int _spawnId;
+    MapUIController _controller;
+
+    /// <summary>Initializes the icon with its spawn identifier.</summary>
+    public void Initialize(int id, MapUIController controller)
+    {
+        _spawnId = id;
+        _controller = controller;
+        var button = GetComponent<Button>();
+        if (button != null)
+            button.onClick.AddListener(OnClicked);
+    }
+
+    void OnClicked()
+    {
+        _controller?.SelectSpawn(_spawnId);
+    }
+}


### PR DESCRIPTION
## Summary
- extend `DataContainerComponent` with spawn selection field and initialize it
- add `MapUIController` and `SpawnIcon` to choose spawn points in UI
- store selected spawn ID via `SpawnSelectionSystem`
- spawn system pulls chosen ID from `DataContainer`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d33ab8a7483328cc35319ec8343c1