### PR TITLE
Implement persistent DataContainer singleton

### DIFF
--- a/Assets/Scripts/Shared/DataContainerAuthoring.cs
+++ b/Assets/Scripts/Shared/DataContainerAuthoring.cs
@@ -1,0 +1,33 @@
+using Unity.Entities;
+using UnityEngine;
+
+/// <summary>
+/// MonoBehaviour used to create the persistent <see cref="DataContainerComponent"/>
+/// at the start of the application.
+/// </summary>
+public class DataContainerAuthoring : MonoBehaviour
+{
+    public string playerName = "Player";
+    public int playerID = 0;
+    public int teamID = 0;
+
+    class Baker : Unity.Entities.Baker<DataContainerAuthoring>
+    {
+        public override void Bake(DataContainerAuthoring authoring)
+        {
+            var entity = GetEntity(TransformUsageFlags.None);
+            AddComponent(entity, new DataContainerComponent
+            {
+                playerID = authoring.playerID,
+                playerName = authoring.playerName,
+                teamID = authoring.teamID,
+                selectedLoadoutID = -1,
+                selectedSquads = default,
+                selectedPerks = default,
+                totalLeadershipUsed = 0,
+                selectedSpawnID = -1,
+                isReady = false
+            });
+        }
+    }
+}

--- a/Assets/Scripts/Shared/DataContainerComponent.cs
+++ b/Assets/Scripts/Shared/DataContainerComponent.cs
@@ -6,14 +6,20 @@ using Unity.Entities;
 /// </summary>
 public struct DataContainerComponent : IComponentData
 {
+    /// <summary>Unique identifier for the local player.</summary>
+    public int playerID;
+
     /// <summary>Name chosen by the local player.</summary>
     public FixedString64Bytes playerName;
+
+    /// <summary>Team identifier for this player.</summary>
+    public int teamID;
 
     /// <summary>Identifier of the loadout selected for the match.</summary>
     public int selectedLoadoutID;
 
     /// <summary>List of squad identifiers of the active loadout.</summary>
-    public FixedList64Bytes<int> selectedSquads;
+    public FixedList32Bytes<int> selectedSquads;
 
     /// <summary>List of perk identifiers selected by the player.</summary>
     public FixedList32Bytes<int> selectedPerks;
@@ -23,9 +29,6 @@ public struct DataContainerComponent : IComponentData
 
     /// <summary>Identifier of the spawn point chosen during preparation.</summary>
     public int selectedSpawnID;
-
-    /// <summary>Team identifier for this player.</summary>
-    public int playerTeam;
 
     /// <summary>True when the player finished setting up and is ready.</summary>
     public bool isReady;

--- a/Assets/Scripts/Shared/DataContainerSystem.cs
+++ b/Assets/Scripts/Shared/DataContainerSystem.cs
@@ -18,13 +18,14 @@ public partial class DataContainerSystem : SystemBase
             Entity entity = em.CreateEntity(typeof(DataContainerComponent));
             em.SetComponentData(entity, new DataContainerComponent
             {
+                playerID = 0,
                 playerName = default,
+                teamID = 0,
                 selectedLoadoutID = -1,
                 selectedSquads = default,
                 selectedPerks = default,
                 totalLeadershipUsed = 0,
                 selectedSpawnID = -1,
-                playerTeam = 0,
                 isReady = false
             });
         }

--- a/Assets/Scripts/UI/MapUIController.cs
+++ b/Assets/Scripts/UI/MapUIController.cs
@@ -27,7 +27,7 @@ public class MapUIController : MonoBehaviour
 
         foreach (var sp in points)
         {
-            if (sp.teamID != data.playerTeam || !sp.isActive)
+            if (sp.teamID != data.teamID || !sp.isActive)
                 continue;
 
             if (_spawnIconPrefab != null && _spawnContainer != null)


### PR DESCRIPTION
## Summary
- expand `DataContainerComponent` with new fields and smaller lists
- maintain singleton initialization of the container with the new structure
- create `DataContainerAuthoring` MonoBehaviour for preset values
- adjust MapUIController to use the new field name

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d3960f02c8332b380fea8e6cda062