### PR TITLE
Implement basic hero progression system

### DIFF
--- a/Assets/Scripts/Hero/HeroLevelSystem.cs
+++ b/Assets/Scripts/Hero/HeroLevelSystem.cs
@@ -1,0 +1,100 @@
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+
+/// <summary>
+/// Aggregates XP events for the player hero and handles level progression.
+/// </summary>
+[UpdateInGroup(typeof(SimulationSystemGroup))]
+public partial class HeroLevelSystem : SystemBase
+{
+    LocalSaveSystem.PlayerProgressData _saveData;
+    bool _initialized;
+
+    protected override void OnCreate()
+    {
+        base.OnCreate();
+        _saveData = LocalSaveSystem.LoadGame();
+        if (_saveData.heroProgress == null)
+            _saveData.heroProgress = new LocalSaveSystem.HeroProgressData();
+    }
+
+    protected override void OnUpdate()
+    {
+        if (!_initialized)
+        {
+            InitializeProgressComponent();
+            _initialized = true;
+        }
+
+        if (!SystemAPI.TryGetSingletonEntity<HeroProgressComponent>(out var entity))
+            return;
+
+        var progress = SystemAPI.GetComponentRW<HeroProgressComponent>(entity);
+        int gainedXP = 0;
+        var ecb = new EntityCommandBuffer(Allocator.Temp);
+
+        foreach (var (xp, evt) in SystemAPI.Query<RefRO<XPEventComponent>>().WithEntityAccess())
+        {
+            gainedXP += xp.ValueRO.amount;
+            ecb.DestroyEntity(evt);
+        }
+
+        bool save = false;
+
+        if (gainedXP > 0)
+        {
+            progress.ValueRW.currentXP += gainedXP;
+            save = true;
+        }
+
+        while (progress.ValueRO.currentXP >= progress.ValueRO.xpToNextLevel)
+        {
+            progress.ValueRW.currentXP -= progress.ValueRO.xpToNextLevel;
+            progress.ValueRW.level += 1;
+            progress.ValueRW.perkPoints += 1;
+            progress.ValueRW.xpToNextLevel = CalculateNext(progress.ValueRO.level);
+
+            Entity evt = ecb.CreateEntity();
+            ecb.AddComponent(evt, new LevelUpEvent { newLevel = progress.ValueRO.level });
+            save = true;
+        }
+
+        ecb.Playback(EntityManager);
+        ecb.Dispose();
+
+        if (save || IsPostMatch())
+        {
+            _saveData.heroProgress.level = progress.ValueRO.level;
+            _saveData.heroProgress.currentXP = progress.ValueRO.currentXP;
+            _saveData.heroProgress.xpToNextLevel = progress.ValueRO.xpToNextLevel;
+            _saveData.heroProgress.perkPoints = progress.ValueRO.perkPoints;
+            LocalSaveSystem.SaveGame(_saveData);
+        }
+    }
+
+    void InitializeProgressComponent()
+    {
+        if (!SystemAPI.TryGetSingletonEntity<HeroProgressComponent>(out var entity))
+            return;
+
+        var progress = SystemAPI.GetComponentRW<HeroProgressComponent>(entity);
+        progress.ValueRW.level = _saveData.heroProgress.level;
+        progress.ValueRW.currentXP = _saveData.heroProgress.currentXP;
+        progress.ValueRW.xpToNextLevel = _saveData.heroProgress.xpToNextLevel;
+        progress.ValueRW.perkPoints = _saveData.heroProgress.perkPoints;
+    }
+
+    static int CalculateNext(int level)
+    {
+        return (int)math.floor(100 * math.pow(1.2f, level - 1));
+    }
+
+    bool IsPostMatch()
+    {
+        if (SystemAPI.TryGetSingleton<GameStateComponent>(out var state))
+            return state.currentPhase == GamePhase.PostPartida;
+        return false;
+    }
+}

--- a/Assets/Scripts/Hero/HeroProgressComponent.cs
+++ b/Assets/Scripts/Hero/HeroProgressComponent.cs
@@ -1,0 +1,19 @@
+using Unity.Entities;
+
+/// <summary>
+/// Stores persistent progression data for the player's hero.
+/// </summary>
+public struct HeroProgressComponent : IComponentData
+{
+    /// <summary>Current hero level.</summary>
+    public int level;
+
+    /// <summary>Experience points accumulated towards the next level.</summary>
+    public int currentXP;
+
+    /// <summary>XP required to reach the next level.</summary>
+    public int xpToNextLevel;
+
+    /// <summary>Perk points available to spend.</summary>
+    public int perkPoints;
+}

--- a/Assets/Scripts/Hero/LevelUpEvent.cs
+++ b/Assets/Scripts/Hero/LevelUpEvent.cs
@@ -1,0 +1,10 @@
+using Unity.Entities;
+
+/// <summary>
+/// Event emitted when the hero gains a level.
+/// </summary>
+public struct LevelUpEvent : IComponentData
+{
+    /// <summary>New level obtained.</summary>
+    public int newLevel;
+}

--- a/Assets/Scripts/Hero/XPEventComponent.cs
+++ b/Assets/Scripts/Hero/XPEventComponent.cs
@@ -1,0 +1,13 @@
+using Unity.Entities;
+
+/// <summary>
+/// Event component generated when the player earns experience points.
+/// </summary>
+public struct XPEventComponent : IComponentData
+{
+    /// <summary>Amount of XP granted.</summary>
+    public int amount;
+
+    /// <summary>Reason the XP was awarded.</summary>
+    public XPSource source;
+}

--- a/Assets/Scripts/Hero/XPSource.cs
+++ b/Assets/Scripts/Hero/XPSource.cs
@@ -1,0 +1,10 @@
+/// <summary>
+/// Identifies the origin of an experience award.
+/// </summary>
+public enum XPSource
+{
+    Kill,
+    Capture,
+    Assist,
+    Victory
+}

--- a/Assets/Scripts/Shared/DataContainerSystem.cs
+++ b/Assets/Scripts/Shared/DataContainerSystem.cs
@@ -15,7 +15,12 @@ public partial class DataContainerSystem : SystemBase
         if (!SystemAPI.TryGetSingletonEntity<DataContainerComponent>(out _))
         {
             var em = World.DefaultGameObjectInjectionWorld.EntityManager;
-            Entity entity = em.CreateEntity(typeof(DataContainerComponent));
+            Entity entity = em.CreateEntity(typeof(DataContainerComponent), typeof(HeroProgressComponent));
+
+            var save = LocalSaveSystem.LoadGame();
+            if (save.heroProgress == null)
+                save.heroProgress = new LocalSaveSystem.HeroProgressData();
+
             em.SetComponentData(entity, new DataContainerComponent
             {
                 playerID = 0,
@@ -27,6 +32,14 @@ public partial class DataContainerSystem : SystemBase
                 totalLeadershipUsed = 0,
                 selectedSpawnID = -1,
                 isReady = false
+            });
+
+            em.SetComponentData(entity, new HeroProgressComponent
+            {
+                level = save.heroProgress.level,
+                currentXP = save.heroProgress.currentXP,
+                xpToNextLevel = save.heroProgress.xpToNextLevel,
+                perkPoints = save.heroProgress.perkPoints
             });
         }
     }

--- a/Assets/Scripts/Shared/LocalSaveSystem.cs
+++ b/Assets/Scripts/Shared/LocalSaveSystem.cs
@@ -14,6 +14,17 @@ public static class LocalSaveSystem
     public class PlayerProgressData
     {
         public List<LoadoutData> loadouts = new();
+        public HeroProgressData heroProgress = new();
+    }
+
+    /// <summary>Serializable representation of the hero progression.</summary>
+    [Serializable]
+    public class HeroProgressData
+    {
+        public int level = 1;
+        public int currentXP = 0;
+        public int xpToNextLevel = 100;
+        public int perkPoints = 0;
     }
 
     /// <summary>Serializable representation of a loadout.</summary>


### PR DESCRIPTION
## Summary
- store hero progress data in LocalSaveSystem
- create HeroProgressComponent with level and XP info
- add XP event and level-up event components
- implement HeroLevelSystem to process XP and save progress
- load saved progress through DataContainerSystem

## Testing
- `dotnet build prototipo_curado.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d3cf8e3448332b3811d57a1b054d5