### PR TITLE
Implement Hero attribute validation system

### DIFF
--- a/Assets/Scripts/Hero/HeroAttributeSystem.cs
+++ b/Assets/Scripts/Hero/HeroAttributeSystem.cs
@@ -1,0 +1,76 @@
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+
+/// <summary>
+/// Validates hero attribute assignments against <see cref="HeroClassDefinition"/>
+/// limits. Runs only outside of combat.
+/// </summary>
+[UpdateInGroup(typeof(SimulationSystemGroup))]
+public partial class HeroAttributeSystem : SystemBase
+{
+    protected override void OnUpdate()
+    {
+        // Skip validation while in combat.
+        if (SystemAPI.TryGetSingleton<GameStateComponent>(out var state) &&
+            state.currentPhase == GamePhase.Combate)
+            return;
+
+        var defLookup = GetComponentLookup<HeroClassDefinitionComponent>(true);
+        var ecb = new EntityCommandBuffer(Allocator.Temp);
+
+        foreach (var (attr, entity) in SystemAPI
+                     .Query<RefRW<HeroAttributesComponent>>()
+                     .WithEntityAccess())
+        {
+            if (!defLookup.TryGetComponent(attr.ValueRO.classDefinition, out var def))
+                continue;
+
+            var data = attr.ValueRW;
+            bool changed = false;
+
+            changed |= Validate(ref data.fuerza, def.minFuerza, def.maxFuerza,
+                                HeroAttributeType.Fuerza, entity, ref ecb);
+            changed |= Validate(ref data.destreza, def.minDestreza, def.maxDestreza,
+                                HeroAttributeType.Destreza, entity, ref ecb);
+            changed |= Validate(ref data.armadura, def.minArmadura, def.maxArmadura,
+                                HeroAttributeType.Armadura, entity, ref ecb);
+            changed |= Validate(ref data.vitalidad, def.minVitalidad, def.maxVitalidad,
+                                HeroAttributeType.Vitalidad, entity, ref ecb);
+
+            if (changed)
+                attr.ValueRW = data;
+        }
+
+        ecb.Playback(EntityManager);
+        ecb.Dispose();
+    }
+
+    static bool Validate(ref int value, int min, int max, HeroAttributeType type,
+                          Entity target, ref EntityCommandBuffer ecb)
+    {
+        if (value < min)
+        {
+            ecb.AddComponent(target, new AttributeLimitEvent
+            {
+                attribute = type,
+                attemptedValue = value
+            });
+            value = min;
+            return true;
+        }
+        if (value > max)
+        {
+            ecb.AddComponent(target, new AttributeLimitEvent
+            {
+                attribute = type,
+                attemptedValue = value
+            });
+            value = max;
+            return true;
+        }
+        return false;
+    }
+}
+

--- a/Assets/Scripts/Hero/HeroAttributeType.cs
+++ b/Assets/Scripts/Hero/HeroAttributeType.cs
@@ -1,0 +1,30 @@
+using Unity.Entities;
+
+/// <summary>
+/// Identifies a hero attribute validated by <see cref="HeroAttributeSystem"/>.
+/// </summary>
+public enum HeroAttributeType
+{
+    /// <summary>Strength attribute.</summary>
+    Fuerza,
+    /// <summary>Dexterity attribute.</summary>
+    Destreza,
+    /// <summary>Armor attribute.</summary>
+    Armadura,
+    /// <summary>Vitality attribute.</summary>
+    Vitalidad
+}
+
+/// <summary>
+/// Event emitted when the player tries to assign a value outside the limits
+/// allowed by their hero class.
+/// </summary>
+public struct AttributeLimitEvent : IComponentData
+{
+    /// <summary>Attribute that exceeded the allowed range.</summary>
+    public HeroAttributeType attribute;
+
+    /// <summary>Value that was attempted to be set.</summary>
+    public int attemptedValue;
+}
+


### PR DESCRIPTION
## Summary
- add `HeroAttributeType` enum and `AttributeLimitEvent` to notify UI of invalid assignments
- implement `HeroAttributeSystem` to clamp hero attribute values using the limits from `HeroClassDefinition`

## Testing
- `dotnet build prototipo_curado.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d61f0d9a083329f4e1c99b5661fad