### PR TITLE
Implement team chat MVP

### DIFF
--- a/Assets/Scripts/UI/Chat/ChatMessageComponent.cs
+++ b/Assets/Scripts/UI/Chat/ChatMessageComponent.cs
@@ -1,0 +1,22 @@
+using Unity.Collections;
+using Unity.Entities;
+
+/// <summary>
+/// Component representing a single chat message.
+/// Created on the client when a player sends a message
+/// and removed after it has been processed by <see cref="ChatSystem"/>.
+/// </summary>
+public struct ChatMessageComponent : IComponentData
+{
+    /// <summary>Name of the player sending the message.</summary>
+    public FixedString64Bytes senderName;
+
+    /// <summary>Text content of the chat message.</summary>
+    public FixedString128Bytes message;
+
+    /// <summary>
+    /// True if the message should only be delivered to team mates.
+    /// The MVP always sets this to true.
+    /// </summary>
+    public bool teamOnly;
+}

--- a/Assets/Scripts/UI/Chat/ChatSystem.cs
+++ b/Assets/Scripts/UI/Chat/ChatSystem.cs
@@ -1,0 +1,76 @@
+using Unity.Collections;
+using Unity.Entities;
+
+/// <summary>
+/// System responsible for storing chat messages in a history buffer.
+/// It converts <see cref="ChatMessageComponent"/> entities into
+/// <see cref="ChatHistoryElement"/> entries and removes the original entity.
+/// The buffer can then be read by the UI layer.
+/// </summary>
+[UpdateInGroup(typeof(SimulationSystemGroup))]
+public partial class ChatSystem : SystemBase
+{
+    const int DefaultHistoryLimit = 30;
+
+    protected override void OnCreate()
+    {
+        base.OnCreate();
+
+        // Ensure a singleton entity with a dynamic buffer exists
+        if (!SystemAPI.TryGetSingletonEntity<ChatHistoryState>(out _))
+        {
+            var em = World.DefaultGameObjectInjectionWorld.EntityManager;
+            Entity entity = em.CreateEntity(typeof(ChatHistoryState));
+            em.AddBuffer<ChatHistoryElement>(entity);
+            em.SetComponentData(entity, new ChatHistoryState
+            {
+                historyLimit = DefaultHistoryLimit
+            });
+        }
+    }
+
+    protected override void OnUpdate()
+    {
+        if (!SystemAPI.TryGetSingletonEntity<ChatHistoryState>(out var historyEntity))
+            return;
+
+        DynamicBuffer<ChatHistoryElement> history = SystemAPI.GetBuffer<ChatHistoryElement>(historyEntity);
+        int limit = SystemAPI.GetComponent<ChatHistoryState>(historyEntity).historyLimit;
+
+        var ecb = new EntityCommandBuffer(Allocator.Temp);
+
+        foreach (var (msg, ent) in SystemAPI.Query<ChatMessageComponent>().WithEntityAccess())
+        {
+            history.Add(new ChatHistoryElement
+            {
+                senderName = msg.senderName,
+                message = msg.message
+            });
+
+            if (history.Length > limit)
+                history.RemoveAt(0);
+
+            ecb.DestroyEntity(ent);
+        }
+
+        ecb.Playback(EntityManager);
+        ecb.Dispose();
+    }
+}
+
+/// <summary>
+/// Buffer element storing a formatted chat message.
+/// </summary>
+public struct ChatHistoryElement : IBufferElementData
+{
+    public FixedString64Bytes senderName;
+    public FixedString128Bytes message;
+}
+
+/// <summary>
+/// Singleton component holding configuration for the chat history buffer.
+/// </summary>
+public struct ChatHistoryState : IComponentData
+{
+    public int historyLimit;
+}

--- a/Assets/Scripts/UI/Chat/ChatUIController.cs
+++ b/Assets/Scripts/UI/Chat/ChatUIController.cs
@@ -1,0 +1,170 @@
+using Unity.Collections;
+using Unity.Entities;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.UI;
+using TMPro;
+
+/// <summary>
+/// Handles input and display for the in-game chat window.
+/// Messages are stored in a dynamic buffer by <see cref="ChatSystem"/> and
+/// displayed here.
+/// </summary>
+public class ChatUIController : MonoBehaviour
+{
+    [Header("UI References")]
+    [SerializeField] CanvasGroup chatGroup;
+    [SerializeField] TMP_InputField inputField;
+    [SerializeField] ScrollRect scrollRect;
+    [SerializeField] RectTransform messageContainer;
+    [SerializeField] TMP_Text messagePrefab;
+    [SerializeField] int maxMessages = 30;
+
+    EntityManager _em;
+    Entity _historyEntity = Entity.Null;
+    int _lastCount;
+    bool _inputActive;
+
+    void Awake()
+    {
+        _em = World.DefaultGameObjectInjectionWorld.EntityManager;
+    }
+
+    void Start()
+    {
+        TryResolveHistory();
+        if (chatGroup != null)
+            chatGroup.alpha = 0f;
+        if (inputField != null)
+            inputField.gameObject.SetActive(false);
+    }
+
+    void Update()
+    {
+        var kb = Keyboard.current;
+        if (kb == null)
+            return;
+
+        if (kb.tKey != null && kb.tKey.wasPressedThisFrame)
+        {
+            if (chatGroup != null)
+                chatGroup.alpha = chatGroup.alpha > 0f ? 0f : 1f;
+        }
+
+        if (kb.enterKey != null && kb.enterKey.wasPressedThisFrame)
+        {
+            if (!_inputActive)
+                OpenInput();
+            else
+                SubmitMessage();
+        }
+    }
+
+    void LateUpdate()
+    {
+        if (!TryResolveHistory())
+            return;
+
+        DynamicBuffer<ChatHistoryElement> buffer = _em.GetBuffer<ChatHistoryElement>(_historyEntity);
+        while (_lastCount < buffer.Length)
+        {
+            var entry = buffer[_lastCount];
+            AppendMessage(entry.senderName.ToString(), entry.message.ToString());
+            _lastCount++;
+        }
+    }
+
+    void OpenInput()
+    {
+        if (chatGroup != null)
+            chatGroup.alpha = 1f;
+        if (inputField != null)
+        {
+            inputField.gameObject.SetActive(true);
+            inputField.text = string.Empty;
+            inputField.ActivateInputField();
+        }
+        _inputActive = true;
+    }
+
+    void CloseInput()
+    {
+        if (inputField != null)
+            inputField.DeactivateInputField();
+        _inputActive = false;
+    }
+
+    void SubmitMessage()
+    {
+        string text = inputField != null ? inputField.text : string.Empty;
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            CloseInput();
+            return;
+        }
+
+        FixedString64Bytes sender = GetPlayerName();
+        var msg = new ChatMessageComponent
+        {
+            senderName = sender,
+            message = new FixedString128Bytes(text),
+            teamOnly = true
+        };
+
+        Entity e = _em.CreateEntity(typeof(ChatMessageComponent));
+        _em.SetComponentData(e, msg);
+
+        if (inputField != null)
+            inputField.text = string.Empty;
+
+        CloseInput();
+    }
+
+    void AppendMessage(string sender, string message)
+    {
+        if (messagePrefab == null || messageContainer == null)
+            return;
+
+        TMP_Text txt = Instantiate(messagePrefab, messageContainer);
+        txt.text = $"<b>{sender}:</b> {message}";
+        txt.color = GetTeamColor();
+        LayoutRebuilder.ForceRebuildLayoutImmediate(messageContainer);
+        if (scrollRect != null)
+            scrollRect.verticalNormalizedPosition = 0f;
+
+        if (messageContainer.childCount > maxMessages)
+            Destroy(messageContainer.GetChild(0).gameObject);
+    }
+
+    FixedString64Bytes GetPlayerName()
+    {
+        if (SystemAPI.TryGetSingleton<DataContainerComponent>(out var data))
+            return data.playerName;
+        return new FixedString64Bytes("Player");
+    }
+
+    Color GetTeamColor()
+    {
+        if (SystemAPI.TryGetSingleton<DataContainerComponent>(out var data))
+        {
+            return ((Team)data.teamID) switch
+            {
+                Team.TeamA => Color.blue,
+                Team.TeamB => Color.red,
+                _ => Color.white
+            };
+        }
+        return Color.white;
+    }
+
+    bool TryResolveHistory()
+    {
+        if (_historyEntity != Entity.Null && _em.Exists(_historyEntity))
+            return true;
+
+        if (SystemAPI.TryGetSingletonEntity<ChatHistoryState>(out _historyEntity))
+            return true;
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- add ChatMessageComponent for storing individual chat entries
- implement ChatSystem that collects messages into a history buffer
- create ChatUIController to handle input and display messages

## Testing
- `npm test` *(fails: package.json missing)*
- `dotnet test` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685d89692728833283a11f75945d08b6