### PR TITLE
Add object pooling system

### DIFF
--- a/Assets/Scripts/Shared/Pooling/ObjectPoolSystem.cs
+++ b/Assets/Scripts/Shared/Pooling/ObjectPoolSystem.cs
@@ -1,0 +1,115 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Singleton manager that stores and reuses temporary <see cref="GameObject"/> instances.
+/// Used for projectiles and ability effects to avoid frequent allocations.
+/// </summary>
+public class ObjectPoolSystem : MonoBehaviour
+{
+    /// <summary>Global access instance.</summary>
+    public static ObjectPoolSystem Instance { get; private set; }
+
+    readonly Dictionary<string, Queue<GameObject>> _pools = new();
+    readonly Dictionary<string, GameObject> _prefabs = new();
+
+    void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    /// <summary>
+    /// Preloads a number of instances for a given prefab.
+    /// </summary>
+    /// <param name="key">Pool identifier.</param>
+    /// <param name="prefab">Prefab to instantiate.</param>
+    /// <param name="count">Number of instances to create.</param>
+    public void WarmUpPool(string key, GameObject prefab, int count)
+    {
+        if (string.IsNullOrEmpty(key) || prefab == null || count <= 0)
+            return;
+
+        if (!_pools.TryGetValue(key, out Queue<GameObject> queue))
+        {
+            queue = new Queue<GameObject>(count);
+            _pools[key] = queue;
+        }
+
+        if (!_prefabs.ContainsKey(key))
+            _prefabs[key] = prefab;
+
+        while (queue.Count < count)
+        {
+            GameObject obj = Instantiate(prefab);
+            obj.SetActive(false);
+            RegisterPoolKey(obj, key);
+            queue.Enqueue(obj);
+        }
+    }
+
+    /// <summary>
+    /// Retrieves an instance from the pool or creates one if empty.
+    /// </summary>
+    /// <param name="key">Pool identifier.</param>
+    public GameObject GetFromPool(string key)
+    {
+        if (string.IsNullOrEmpty(key))
+            return null;
+
+        if (!_pools.TryGetValue(key, out Queue<GameObject> queue))
+            queue = _pools[key] = new Queue<GameObject>();
+
+        GameObject obj;
+        if (queue.Count > 0)
+        {
+            obj = queue.Dequeue();
+            if (obj == null)
+                return GetFromPool(key);
+        }
+        else if (_prefabs.TryGetValue(key, out GameObject prefab))
+        {
+            obj = Instantiate(prefab);
+            RegisterPoolKey(obj, key);
+        }
+        else
+        {
+            return null;
+        }
+
+        obj.SetActive(true);
+        PoolableObject poolable = obj.GetComponent<PoolableObject>();
+        if (poolable != null)
+            poolable.OnSpawned();
+        return obj;
+    }
+
+    /// <summary>
+    /// Returns the object to its pool and deactivates it.
+    /// </summary>
+    /// <param name="key">Pool identifier.</param>
+    /// <param name="obj">Instance to recycle.</param>
+    public void ReturnToPool(string key, GameObject obj)
+    {
+        if (obj == null || string.IsNullOrEmpty(key))
+            return;
+
+        if (!_pools.TryGetValue(key, out Queue<GameObject> queue))
+            queue = _pools[key] = new Queue<GameObject>();
+
+        obj.SetActive(false);
+        queue.Enqueue(obj);
+    }
+
+    static void RegisterPoolKey(GameObject obj, string key)
+    {
+        PoolableObject poolable = obj.GetComponent<PoolableObject>();
+        if (poolable != null)
+            poolable.poolKey = key;
+    }
+}

--- a/Assets/Scripts/Shared/Pooling/PoolBootstrapper.cs
+++ b/Assets/Scripts/Shared/Pooling/PoolBootstrapper.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Initializes object pools at scene load time.
+/// </summary>
+public class PoolBootstrapper : MonoBehaviour
+{
+    [System.Serializable]
+    public class PoolEntry
+    {
+        public string key = string.Empty;
+        public GameObject prefab = null;
+        public int preloadCount = 0;
+    }
+
+    [SerializeField] List<PoolEntry> pools = new();
+
+    void Awake()
+    {
+        if (ObjectPoolSystem.Instance == null)
+        {
+            var manager = new GameObject(nameof(ObjectPoolSystem));
+            manager.AddComponent<ObjectPoolSystem>();
+        }
+
+        foreach (var entry in pools)
+        {
+            if (entry.prefab != null && !string.IsNullOrEmpty(entry.key))
+                ObjectPoolSystem.Instance.WarmUpPool(entry.key, entry.prefab, entry.preloadCount);
+        }
+    }
+}

--- a/Assets/Scripts/Shared/Pooling/PoolableObject.cs
+++ b/Assets/Scripts/Shared/Pooling/PoolableObject.cs
@@ -1,0 +1,42 @@
+using UnityEngine;
+
+/// <summary>
+/// Base component for objects managed by <see cref="ObjectPoolSystem"/>.
+/// Handles automatic return to the pool if a lifetime is specified.
+/// </summary>
+public class PoolableObject : MonoBehaviour
+{
+    [HideInInspector]
+    public string poolKey = string.Empty;
+
+    [Tooltip("Seconds before automatically returning to the pool. 0 = manual return")]
+    public float autoReturnTime = 0f;
+
+    float _timer;
+
+    /// <summary>Called when the object is retrieved from the pool.</summary>
+    public virtual void OnSpawned()
+    {
+        if (autoReturnTime > 0f)
+            _timer = autoReturnTime;
+    }
+
+    void Update()
+    {
+        if (autoReturnTime <= 0f)
+            return;
+
+        _timer -= Time.deltaTime;
+        if (_timer <= 0f)
+            ReturnToPool();
+    }
+
+    /// <summary>Returns this instance back to its pool.</summary>
+    public void ReturnToPool()
+    {
+        if (ObjectPoolSystem.Instance != null)
+            ObjectPoolSystem.Instance.ReturnToPool(poolKey, gameObject);
+        else
+            Destroy(gameObject);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ObjectPoolSystem` singleton to manage pooled prefabs
- implement `PoolableObject` base behaviour with optional auto-return
- provide `PoolBootstrapper` for scene-based initialization

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d96b11e2c833299e03e7d8d406f70