### PR TITLE
Add HeroAbilityData ScriptableObject

### DIFF
--- a/Assets/Scripts/Hero/HeroAbilityData.cs
+++ b/Assets/Scripts/Hero/HeroAbilityData.cs
@@ -1,0 +1,47 @@
+using UnityEngine;
+
+/// <summary>
+/// Data defining an active hero ability used during combat.
+/// Loaded by <see cref="HeroClassDefinition"/> and referenced by the HUD.
+/// </summary>
+[CreateAssetMenu(menuName = "Hero/Ability Data")]
+public class HeroAbilityData : ScriptableObject
+{
+    /// <summary>Name shown to players.</summary>
+    public string abilityName;
+
+    /// <summary>Icon representing the ability in UI.</summary>
+    public Sprite icon;
+
+    /// <summary>Tooltip or descriptive text.</summary>
+    public string description;
+
+    /// <summary>Cooldown time in seconds before the ability can be reused.</summary>
+    public float cooldown;
+
+    /// <summary>Stamina required to activate the ability.</summary>
+    public float staminaCost;
+
+    /// <summary>Button slot this ability belongs to (Q, E, R or Ultimate).</summary>
+    public HeroAbilityCategory category;
+
+    /// <summary>Optional animation tag triggered when used.</summary>
+    public string animationTag;
+
+    /// <summary>Optional radius for area based effects.</summary>
+    public float areaRadius;
+
+    /// <summary>Optional multiplier applied to base damage.</summary>
+    public float damageMultiplier;
+}
+
+/// <summary>
+/// Categories mapping abilities to input keys.
+/// </summary>
+public enum HeroAbilityCategory
+{
+    Q,
+    E,
+    R,
+    Ultimate
+}


### PR DESCRIPTION
## Summary
- add ScriptableObject `HeroAbilityData` with cooldown, stamina cost, UI info and optional fields
- define `HeroAbilityCategory` enum for Q/E/R/F slots

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3eaccb4083328327703042fdb8ea