### PR TITLE
Fix SystemAPI AddComponent usage

### DIFF
--- a/Assets/Scripts/Combat/DamageCalculationSystem.cs
+++ b/Assets/Scripts/Combat/DamageCalculationSystem.cs
@@ -20,14 +20,14 @@ public partial class DamageCalculationSystem : SystemBase
             if (!SystemAPI.Exists(pending.ValueRO.target) ||
                 !SystemAPI.Exists(pending.ValueRO.damageProfile))
             {
-                SystemAPI.RemoveComponent<PendingDamageEvent>(entity);
+                EntityManager.RemoveComponent<PendingDamageEvent>(entity);
                 continue;
             }
 
             // Skip if target already dead
             if (SystemAPI.HasComponent<IsDeadComponent>(pending.ValueRO.target))
             {
-                SystemAPI.RemoveComponent<PendingDamageEvent>(entity);
+                EntityManager.RemoveComponent<PendingDamageEvent>(entity);
                 continue;
             }
 
@@ -38,7 +38,7 @@ public partial class DamageCalculationSystem : SystemBase
                 var targetTeam = SystemAPI.GetComponent<TeamComponent>(pending.ValueRO.target).value;
                 if (targetTeam == pending.ValueRO.sourceTeam)
                 {
-                    SystemAPI.RemoveComponent<PendingDamageEvent>(entity);
+                    EntityManager.RemoveComponent<PendingDamageEvent>(entity);
                     continue;
                 }
             }
@@ -84,11 +84,11 @@ public partial class DamageCalculationSystem : SystemBase
                 if (health.ValueRW.currentHealth <= 0f &&
                     !SystemAPI.HasComponent<IsDeadComponent>(pending.ValueRO.target))
                 {
-                    SystemAPI.AddComponent<IsDeadComponent>(pending.ValueRO.target);
+                    EntityManager.AddComponent<IsDeadComponent>(pending.ValueRO.target);
                 }
             }
 
-            SystemAPI.RemoveComponent<PendingDamageEvent>(entity);
+            EntityManager.RemoveComponent<PendingDamageEvent>(entity);
         }
     }
 }

--- a/Assets/Scripts/Combat/SquadAttackSystem.cs
+++ b/Assets/Scripts/Combat/SquadAttackSystem.cs
@@ -84,7 +84,7 @@ public partial class SquadAttackSystem : SystemBase
                         if (SystemAPI.HasComponent<TeamComponent>(unit))
                             team = SystemAPI.GetComponent<TeamComponent>(unit).value;
 
-                        SystemAPI.AddComponent(unit, new PendingDamageEvent
+                        EntityManager.AddComponentData(unit, new PendingDamageEvent
                         {
                             target = chosen,
                             damageSource = unit,

--- a/Assets/Scripts/Combat/UnitAttackSystem.cs
+++ b/Assets/Scripts/Combat/UnitAttackSystem.cs
@@ -68,7 +68,7 @@ public partial class UnitAttackSystem : SystemBase
                     if (SystemAPI.HasComponent<TeamComponent>(entity))
                         team = SystemAPI.GetComponent<TeamComponent>(entity).value;
 
-                    SystemAPI.AddComponent(entity, new PendingDamageEvent
+                    EntityManager.AddComponentData(entity, new PendingDamageEvent
                     {
                         target = target,
                         damageSource = entity,

--- a/Assets/Scripts/Hero/HeroAttackSystem.cs
+++ b/Assets/Scripts/Hero/HeroAttackSystem.cs
@@ -83,7 +83,7 @@ public partial class HeroAttackSystem : SystemBase
                     if (SystemAPI.HasComponent<TeamComponent>(weapon.ValueRO.owner))
                         team = SystemAPI.GetComponent<TeamComponent>(weapon.ValueRO.owner).value;
 
-                    SystemAPI.AddComponent(weapon.ValueRO.owner, new PendingDamageEvent
+                    EntityManager.AddComponentData(weapon.ValueRO.owner, new PendingDamageEvent
                     {
                         target = hitEntity,
                         damageSource = weapon.ValueRO.owner,

--- a/Assets/Scripts/Squads/FormationSystem.cs
+++ b/Assets/Scripts/Squads/FormationSystem.cs
@@ -76,7 +76,7 @@ public partial class FormationSystem : SystemBase
                 }
                 else
                 {
-                    SystemAPI.AddComponent(unit, new UnitTargetPositionComponent { position = target });
+                    EntityManager.AddComponentData(unit, new UnitTargetPositionComponent { position = target });
                 }
             }
 

--- a/Assets/Scripts/UI/MapUIController.cs
+++ b/Assets/Scripts/UI/MapUIController.cs
@@ -64,7 +64,7 @@ public class MapUIController : MonoBehaviour
             if (em.HasComponent<SpawnSelectionRequest>(hero))
                 em.SetComponentData(hero, new SpawnSelectionRequest { spawnId = spawnId });
             else
-                em.AddComponent(hero, new SpawnSelectionRequest { spawnId = spawnId });
+                em.AddComponentData(hero, new SpawnSelectionRequest { spawnId = spawnId });
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace invalid `SystemAPI.AddComponent` and `SystemAPI.RemoveComponent` calls
- update systems to use `EntityManager` APIs instead
- fix spawn selection component addition

## Testing
- `dotnet build prototipo_curado.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e558709048332a7ca2f1bcd86c0d5