### PR TITLE
Fix using var on mutable Unity collections

### DIFF
--- a/Assets/Scripts/Combat/UnitTargetingSystem.cs
+++ b/Assets/Scripts/Combat/UnitTargetingSystem.cs
@@ -24,7 +24,7 @@ public partial class UnitTargetingSystem : SystemBase
                           (state.ValueRO.currentOrder == SquadOrderType.HoldPosition));
 
             // Temporary map to track how many units are attacking each enemy
-            using var enemyCounts = new NativeParallelHashMap<Entity, int>(16, Allocator.Temp);
+            var enemyCounts = new NativeParallelHashMap<Entity, int>(16, Allocator.Temp);
 
             // First pass: choose closest target for each unit
             for (int i = 0; i < units.Length; i++)
@@ -128,6 +128,8 @@ public partial class UnitTargetingSystem : SystemBase
                     }
                 }
             }
+
+            enemyCounts.Dispose();
         }
     }
 }

--- a/Assets/Scripts/Hero/HeroAttackSystem.cs
+++ b/Assets/Scripts/Hero/HeroAttackSystem.cs
@@ -67,7 +67,7 @@ public partial class HeroAttackSystem : SystemBase
                 continue;
 
             var aabb = collider.ValueRO.CalculateAabb(new RigidTransform(transform.ValueRO.Rotation, transform.ValueRO.Position));
-            using var hits = new NativeList<int>(Allocator.Temp);
+            var hits = new NativeList<int>(Allocator.Temp);
             physicsWorld.OverlapAabb(aabb, ref hits, CollisionFilter.Default);
 
             for (int i = 0; i < hits.Length; i++)
@@ -95,6 +95,7 @@ public partial class HeroAttackSystem : SystemBase
                 }
             }
 
+            hits.Dispose();
             weapon.ValueRW.isActive = false;
         }
     }


### PR DESCRIPTION
## Summary
- replace readonly `using var` declarations for mutable Unity collections
- ensure manual disposal of allocated collections

## Testing
- `dotnet test` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e5a0d58108332b56e3a18d58ffa56