### PR TITLE
Fix invalid SystemAPI.Query usages

### DIFF
--- a/Assets/Scripts/Hero/HeroSpawnSystem.cs
+++ b/Assets/Scripts/Hero/HeroSpawnSystem.cs
@@ -11,7 +11,8 @@ public partial class HeroSpawnSystem : SystemBase
 {
     protected override void OnUpdate()
     {
-        var spawnPoints = SystemAPI.Query<RefRO<SpawnPointComponent>>().ToComponentDataArray<SpawnPointComponent>(Allocator.Temp);
+        var spawnPointQuery = GetEntityQuery(ComponentType.ReadOnly<SpawnPointComponent>());
+        var spawnPoints = spawnPointQuery.ToComponentDataArray<SpawnPointComponent>(Allocator.Temp);
         float dt = SystemAPI.Time.DeltaTime;
 
         foreach (var (life, spawnData, team, transform) in

--- a/Assets/Scripts/Map/CaptureZoneTriggerSystem.cs
+++ b/Assets/Scripts/Map/CaptureZoneTriggerSystem.cs
@@ -14,9 +14,6 @@ public partial class CaptureZoneTriggerSystem : SystemBase
     {
         float dt = SystemAPI.Time.DeltaTime;
 
-        var heroQuery = SystemAPI.Query<RefRO<LocalTransform>,
-                                        RefRO<HeroLifeComponent>,
-                                        RefRO<TeamComponent>>();
 
         var linkLookup = GetComponentLookup<ZoneLinkComponent>(true);
         var zoneLookup = GetComponentLookup<ZoneTriggerComponent>();
@@ -38,7 +35,10 @@ public partial class CaptureZoneTriggerSystem : SystemBase
             float radiusSq = zone.ValueRO.radius * zone.ValueRO.radius;
             Team owner = (Team)zone.ValueRO.teamOwner;
 
-            foreach (var (hTransform, life, team) in heroQuery)
+            foreach (var (hTransform, life, team) in
+                     SystemAPI.Query<RefRO<LocalTransform>,
+                                     RefRO<HeroLifeComponent>,
+                                     RefRO<TeamComponent>>())
             {
                 if (!life.ValueRO.isAlive)
                     continue;

--- a/Assets/Scripts/Map/SupplyInteractionSystem.cs
+++ b/Assets/Scripts/Map/SupplyInteractionSystem.cs
@@ -14,10 +14,6 @@ public partial class SupplyInteractionSystem : SystemBase
     {
         float dt = SystemAPI.Time.DeltaTime;
 
-        var heroQuery = SystemAPI.Query<RefRO<LocalTransform>,
-                                        RefRO<HeroLifeComponent>,
-                                        RefRO<TeamComponent>>()
-                                .WithEntityAccess();
 
         var healthLookup = GetComponentLookup<HealthComponent>();
         var staminaLookup = GetComponentLookup<StaminaComponent>();
@@ -39,7 +35,11 @@ public partial class SupplyInteractionSystem : SystemBase
             float radiusSq = zone.ValueRO.radius * zone.ValueRO.radius;
             Team owner = (Team)supply.ValueRO.currentTeam;
 
-            foreach (var (hTransform, life, team, heroEntity) in heroQuery)
+            foreach (var (hTransform, life, team, heroEntity) in
+                     SystemAPI.Query<RefRO<LocalTransform>,
+                                     RefRO<HeroLifeComponent>,
+                                     RefRO<TeamComponent>>()
+                             .WithEntityAccess())
             {
                 if (!life.ValueRO.isAlive)
                     continue;


### PR DESCRIPTION
## Summary
- inline hero queries directly in SupplyInteractionSystem
- inline hero queries directly in CaptureZoneTriggerSystem
- use EntityQuery for spawn points in HeroSpawnSystem

## Testing
- `dotnet format --verify-no-changes` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5bbc17848332818ace4b36332de5