### PR TITLE
Deterministic hero movement

### DIFF
--- a/Assets/Scripts/Hero/HeroMovementAuthoring.cs
+++ b/Assets/Scripts/Hero/HeroMovementAuthoring.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+/// <summary>
+/// Authoring component used to configure <see cref="HeroMovementComponent"/> for DOTS.
+/// </summary>
+public class HeroMovementAuthoring : MonoBehaviour
+{
+    public float movementSpeed = 5f;
+}

--- a/Assets/Scripts/Hero/HeroMovementBaker.cs
+++ b/Assets/Scripts/Hero/HeroMovementBaker.cs
@@ -1,0 +1,16 @@
+using Unity.Entities;
+
+/// <summary>
+/// Baker for <see cref="HeroMovementAuthoring"/>. Adds <see cref="HeroMovementComponent"/> during baking.
+/// </summary>
+public class HeroMovementBaker : Baker<HeroMovementAuthoring>
+{
+    public override void Bake(HeroMovementAuthoring authoring)
+    {
+        var entity = GetEntity(TransformUsageFlags.Dynamic);
+        AddComponent(entity, new HeroMovementComponent
+        {
+            movementSpeed = authoring.movementSpeed
+        });
+    }
+}

--- a/Assets/Scripts/Hero/HeroMovementComponent.cs
+++ b/Assets/Scripts/Hero/HeroMovementComponent.cs
@@ -1,0 +1,10 @@
+using Unity.Entities;
+
+/// <summary>
+/// Provides basic movement speed for the hero.
+/// </summary>
+public struct HeroMovementComponent : IComponentData
+{
+    /// <summary>World units moved per second when walking.</summary>
+    public float movementSpeed;
+}

--- a/Assets/Scripts/Hero/HeroMovementSystem.cs
+++ b/Assets/Scripts/Hero/HeroMovementSystem.cs
@@ -1,10 +1,9 @@
 using Unity.Entities;
 using Unity.Mathematics;
 using Unity.Transforms;
-using Unity.Physics;
 
 /// <summary>
-/// Handles physical movement and orientation of the local hero based on
+/// Handles deterministic movement and rotation of the local hero based on
 /// <see cref="HeroInputComponent"/> data.
 /// </summary>
 [UpdateInGroup(typeof(SimulationSystemGroup))]
@@ -14,70 +13,30 @@ public partial class HeroMovementSystem : SystemBase
     {
         float deltaTime = SystemAPI.Time.DeltaTime;
 
-        foreach (var (input, stats, life, velocity, mass, transform, entity) in
+        foreach (var (input, movement, life, transform) in
                  SystemAPI.Query<RefRO<HeroInputComponent>,
-                                 RefRO<HeroStatsComponent>,
+                                 RefRO<HeroMovementComponent>,
                                  RefRO<HeroLifeComponent>,
-                                 RefRW<PhysicsVelocity>,
-                                 RefRO<PhysicsMass>,
                                  RefRW<LocalTransform>>()
-                        .WithAll<IsLocalPlayer>()
-                        .WithEntityAccess())
+                        .WithAll<IsLocalPlayer>())
         {
-            // Debug: Identifica la entidad y sus componentes clave
-            // UnityEngine.Debug.Log($"[HeroMovementSystem] Entity: {entity}, isAlive: {life.ValueRO.isAlive}, baseSpeed: {stats.ValueRO.baseSpeed}, sprintMult: {stats.ValueRO.sprintMultiplier}, jumpForce: {stats.ValueRO.jumpForce}");
-            // UnityEngine.Debug.Log($"[HeroMovementSystem] Input: moveInput={input.ValueRO.moveInput}, sprint={input.ValueRO.isSprinting}, jump={input.ValueRO.isJumping}");
-            // UnityEngine.Debug.Log($"[HeroMovementSystem] PhysicsVelocity antes: {velocity.ValueRW.Linear}");
-
             if (!life.ValueRO.isAlive)
                 continue;
 
-            // --- Movimiento tipo third person, sin rebotes ni rotaciones físicas ---
-            // Calcula la dirección de movimiento en el plano XZ
-            float3 move = new float3(input.ValueRO.moveInput.x, 0f, input.ValueRO.moveInput.y);
-            float moveMagnitude = math.length(move);
-            float3 moveDir = moveMagnitude > 0f ? math.normalize(move) : float3.zero;
+            float2 moveInput = input.ValueRO.moveInput;
+            float3 forward = math.forward(transform.ValueRO.Rotation);
+            float3 right = math.normalizesafe(math.cross(math.up(), forward));
 
-            // Aplica velocidad solo en el plano XZ
-            float speed = stats.ValueRO.baseSpeed;
-            if (input.ValueRO.isSprinting)
-                speed *= stats.ValueRO.sprintMultiplier;
+            float3 desired = forward * moveInput.y + right * moveInput.x;
+            float magnitude = math.length(desired);
 
-            float3 targetVel = moveDir * speed;
-            var vel = velocity.ValueRW;
-
-            // Suaviza el cambio de velocidad (aceleración/frenado)
-            float acceleration = 40f; // Más alto = más responsivo
-            vel.Linear.x = math.lerp(vel.Linear.x, targetVel.x, acceleration * deltaTime);
-            vel.Linear.z = math.lerp(vel.Linear.z, targetVel.z, acceleration * deltaTime);
-
-            // Mantén la velocidad vertical (gravedad DOTS Physics)
-            // Salto
-            if (input.ValueRO.isJumping)
+            if (magnitude > 0f)
             {
-                if (SystemAPI.HasComponent<HeroGroundState>(entity) &&
-                    SystemAPI.GetComponent<HeroGroundState>(entity).isGrounded)
-                {
-                    vel.Linear.y = stats.ValueRO.jumpForce;
-                    var ground = SystemAPI.GetComponentRW<HeroGroundState>(entity);
-                    ground.ValueRW.isGrounded = false;
-                }
-            }
+                float3 direction = desired / magnitude;
+                transform.ValueRW.Position += direction * movement.ValueRO.movementSpeed * deltaTime;
 
-            velocity.ValueRW = vel;
-
-            // --- Rotación: solo gira hacia la dirección de movimiento si hay input ---
-            if (moveMagnitude > 0.01f)
-            {
-                quaternion targetRot = quaternion.LookRotationSafe(moveDir, math.up());
+                quaternion targetRot = quaternion.LookRotationSafe(direction, math.up());
                 transform.ValueRW.Rotation = math.slerp(transform.ValueRW.Rotation, targetRot, deltaTime * 10f);
-            }
-            else
-            {
-                // Mantén la rotación solo en Y si no hay input
-                float3 forward = math.forward(transform.ValueRW.Rotation);
-                float yAngle = math.atan2(forward.x, forward.z);
-                transform.ValueRW.Rotation = quaternion.RotateY(yAngle);
             }
         }
     }


### PR DESCRIPTION
## Summary
- add HeroMovementComponent with a configurable movementSpeed
- create authoring and baker to add HeroMovementComponent at bake time
- refactor HeroMovementSystem to directly change LocalTransform position and rotation without physics

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862ae7d5e7083329ac6a4c435e63162